### PR TITLE
node_modulesをボリュームマウントに変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     command: tail -f /dev/null
     volumes:
       - .:/quitcost
+      - node_modules:/quitcost/node_modules
     ports:
       - "3000:3000"
       # Ports required for debugging
@@ -22,3 +23,5 @@ services:
       BINDING: "0.0.0.0"
     depends_on:
       - db
+volumes:
+  node_modules:


### PR DESCRIPTION
## やったこと

- refs: #48 
- Docker環境高速化のために、node_modulesをボリュームマウントに変更

## 備考

- node_modulesだけでかなり速度向上が見込まれたため、本PRではここだけをボリュームマウントにする。
- 今後パフォーマンスが問題になるようであれば、別のフォルダについてもボリュームマウントの対象とする。