### PR TITLE
Issueテンプレート（form形式）を追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,54 @@
+name: バグレポート
+description: バグを見つけたらレポートお願いします。
+assignees: IkumaTadookoro
+labels: ["バグ"]
+body:
+  - type: markdown
+    attributes:
+      value: "バグ報告ありがとうございます！以下のフォームに入力をお願いします"
+  - type: textarea
+    id: description
+    attributes:
+      label: 概要
+      description: 簡潔な説明
+    validations:
+      required: false
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 再現手順
+      description: バグの再現手順
+      placeholder: |
+        1. /fooにアクセス。
+        2. 「投稿」をクリック。
+        3. エラーが表示される。
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待される振る舞い
+      description: 簡潔な説明
+    validations:
+      required: false
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: スクリーンショット
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: 環境
+      placeholder: |
+        - OS: [e.g. iOS]
+        - ブラウザ: [e.g. chrome, safari]
+        - バージョン: [e.g. 22]
+    validations:
+      required: false
+  - type: textarea
+    id: related_issues
+    attributes:
+      label: 関連Issue
+      placeholder: "Ref: #3899"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: 新機能提案
+description: 新機能の提案はこちらから
+assignees: IkumaTadookoro
+labels: ["新機能"]
+body:
+  - type: markdown
+    attributes:
+      value: "新機能提案ありがとうございます！以下のフォームに入力をお願いします"
+  - type: textarea
+    id: description
+    attributes:
+      label: 機能の説明
+      description: 簡潔な説明
+    validations:
+      required: false
+  - type: textarea
+    id: reason
+    attributes:
+      label: なぜこの機能が必要なのか
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,21 @@
+name: タスク
+description: タスクを追加する場合はこちらから
+assignees: IkumaTadookoro
+body:
+  - type: markdown
+    attributes:
+      value: "タスク"
+  - type: textarea
+    id: subtask
+    attributes:
+      label: サブタスク
+      value: |
+        - [ ]
+    validations:
+      required: false
+  - type: textarea
+    id: note
+    attributes:
+      label: メモ
+    validations:
+      required: false


### PR DESCRIPTION
## 目的

- #67 

## やったこと

- 以下のIssueテンプレートを追加
    - 新機能
    - バグ報告
    - タスク
- テンプレートはMarkdownではなく、form形式を採用

## 参考

- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema