### PR TITLE
自動カンバン追加のワークフローを修正

### DIFF
--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -4,11 +4,11 @@ on:
     types: [opened]
 
 jobs:
-  automate-project-columns:
+  register:
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.3.0
+      - uses: alex-page/github-project-automation-plus@v0.7.1
         with:
           project: Kanban
           column: インボックス
-          repo-token: ${{ secrets.QUITCOST_GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GHPROJECT_TOKEN }}


### PR DESCRIPTION
以前のワークフローが機能していなかったため、トークンとワークフローを置き換えて再度設置