### PR TITLE
chore: Rubocopの除外フォルダをMinitestからRSpec用に変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,11 +5,11 @@ inherit_gem:
 
 Metrics/BlockLength:
   Exclude:
-    - test/**/*
+    - spec/**/*
 
 Metrics/ClassLength:
   Exclude:
-    - test/**/*
+    - spec/**/*
 
 AllCops:
   Exclude:


### PR DESCRIPTION
#66 にて、MinitestからRSpecに切り替えたため、対象フォルダもRSpec用に修正する

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
