### PR TITLE
RubyMineのデバッガ用の設定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
   gem 'rspec-rails'
+  gem 'debase'
+  gem 'ruby-debug-ide'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,9 @@ GEM
     childprocess (4.1.0)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    debase (0.2.4.1)
+      debase-ruby_core_source (>= 0.10.2)
+    debase-ruby_core_source (0.10.14)
     diff-lcs (1.5.0)
     erubi (1.10.0)
     factory_bot (6.2.0)
@@ -205,6 +208,8 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     rubocop-rspec (2.6.0)
       rubocop (~> 1.19)
+    ruby-debug-ide (0.7.3)
+      rake (>= 0.8.1)
     ruby-progressbar (1.11.0)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
@@ -275,6 +280,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  debase
   factory_bot_rails
   html2slim
   jbuilder (~> 2.7)
@@ -289,6 +295,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  ruby-debug-ide
   sass-rails (>= 6)
   selenium-webdriver
   slim-rails
@@ -303,4 +310,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.2.31
+   2.2.32

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "3035:3035"
       # Ports required for debugging
       - "1234:1234"
-      - "26168:26168"
+      - "26162:26162"
     environment:
       BINDING: "0.0.0.0"
     depends_on:


### PR DESCRIPTION
RubyMineのデバッガを起動するための設定を追記

- デバッグに必要なdebaseとruby-debug-ideを追加
- ポート26168だと正しく接続できなかったため、ポートフォワードの設定も変更

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
