### PR TITLE
支払対象月の登録時に、1~3月の場合は翌年として登録するように修正

### DIFF
--- a/app/models/insurance_form.rb
+++ b/app/models/insurance_form.rb
@@ -84,7 +84,7 @@ class InsuranceForm # rubocop:disable Metrics/ClassLength
       PaymentTargetMonth::CALENDAR.each_value do |n|
         payment_target_month = PaymentTargetMonth.find_or_initialize_by(
           insurance_id: insurance.id,
-          month: Time.zone.parse("#{year}-#{format('%02d', n)}-01")
+          month: Time.zone.parse("#{n >= PaymentTargetMonth::CALENDAR[:april] ? year : year.next}-#{format('%02d', n)}-01")
         )
         if payment_target_month.persisted?
           payment_target_month.destroy! unless send(:"month#{n}")

--- a/spec/models/insurance_form_spec.rb
+++ b/spec/models/insurance_form_spec.rb
@@ -209,6 +209,51 @@ RSpec.describe InsuranceForm, type: :model do
         let!(:insurance_form) { build(:insurance_form, :all_months_are_target) }
         it { expect { subject }.to change { Insurance.count }.from(0).to(1) }
         it { expect { subject }.to change { PaymentTargetMonth.count }.from(0).to(12) }
+        it 'saves January to March as the following year' do
+          insurance_form.save
+          payment_target_months = Insurance.find_by(year: insurance_form.year, local_gov_code: insurance_form.local_gov_code).payment_target_months
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:january]
+                 end.month.year).to eq insurance_form.year.next
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:february]
+                 end.month.year).to eq insurance_form.year.next
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:march]
+                 end.month.year).to eq insurance_form.year.next
+        end
+
+        it 'saves April to December as the this year' do
+          insurance_form.save
+          payment_target_months = Insurance.find_by(year: insurance_form.year, local_gov_code: insurance_form.local_gov_code).payment_target_months
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:april]
+                 end.month.year).to eq insurance_form.year
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:may]
+                 end.month.year).to eq insurance_form.year
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:june]
+                 end.month.year).to eq insurance_form.year
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:july]
+                 end.month.year).to eq insurance_form.year
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:august]
+                 end.month.year).to eq insurance_form.year
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:september]
+                 end.month.year).to eq insurance_form.year
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:october]
+                 end.month.year).to eq insurance_form.year
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:november]
+                 end.month.year).to eq insurance_form.year
+          expect(payment_target_months.find do |target_month|
+                   target_month.month.month == PaymentTargetMonth::CALENDAR[:december]
+                 end.month.year).to eq insurance_form.year
+        end
       end
 
       context 'when failed to save' do


### PR DESCRIPTION
## やったこと

- 支払対象月の登録時に、1~3月の場合は翌年として登録するように修正
    - 国民健康保険料の適用期間は、会計年度（当年4月から翌年3月）までとなる。そのため、1~3月については翌年のレコードとして登録する必要がある。
- `insurance_form.save`内の処理をメソッドとして抽出
    - Metrics/PerceivedComplexityに違反するため。またメソッドとしても見通しが悪いため、メソッドとして抽出

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
