### PR TITLE
Insuranceのファクトリにおける、関連モデル作成のtraitを複数指定できるように修正

### DIFF
--- a/spec/factories/insurances.rb
+++ b/spec/factories/insurances.rb
@@ -20,13 +20,16 @@ FactoryBot.define do
     care_household_basis { rand(0..100_000) }
     care_limit { rand(0..100_000) }
 
-    trait(:with_payment_target_month) do
+    trait(:with_payment_target_months) do
       transient do
-        month { rand(1..12) }
+        months { PaymentTargetMonth::CALENDAR.values }
       end
 
       after(:create) do |insurance, evaluator|
-        insurance.payment_target_months = [build(:payment_target_month, month: Time.zone.parse("#{insurance.year}-#{format('%02d', evaluator.month)}-01"))]
+        insurance.payment_target_months = evaluator.months.map do |month|
+          year = month >= PaymentTargetMonth::CALENDAR[:april] ? insurance.year : insurance.year.next
+          build(:payment_target_month, month: Time.zone.parse("#{year}-#{format('%02d', month)}-01"))
+        end
       end
     end
   end

--- a/spec/models/insurance_spec.rb
+++ b/spec/models/insurance_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Insurance, type: :model do
   describe 'month_name_is_target?' do
-    let!(:insurance_pay_only_december) { create(:insurance, :with_payment_target_month, month: 12) }
+    let!(:insurance_pay_only_december) { create(:insurance, :with_payment_target_months, months: [12]) }
 
     context 'when insurance has specified month as a payment target' do
       it 'returns true' do

--- a/spec/system/insurance_spec.rb
+++ b/spec/system/insurance_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Insurance', type: :system, js: true do
   end
 
   describe 'update' do
-    before { @insurance = create(:insurance, :with_payment_target_month, month: 1) }
+    before { @insurance = create(:insurance, :with_payment_target_months, months: [1]) }
     scenario 'update a existing record' do
       # FIXME: 更新系のテストの補強
       visit insurances_path
@@ -76,7 +76,7 @@ RSpec.describe 'Insurance', type: :system, js: true do
   end
 
   describe 'destroy' do
-    before { @insurance = create(:insurance, :with_payment_target_month, month: 1) }
+    before { @insurance = create(:insurance, :with_payment_target_months, months: [1]) }
     scenario 'destroy a existing record' do
       visit insurances_path
 


### PR DESCRIPTION
## 変更の背景
PaymentTargetMonthは国民健康保険料の支払対象月をあらわしている。
支払月は通常4ヶ月以上になるため、traitで複数指定できる方が各テストで使用しやすい。そのため今回の変更を適用した。

## 使用方法

```ruby
FactoryBot.create(:insurance, :with_payment_target_months, months: <Array：作成対象の月[Integer]>)
```

### 例

3月から5月のレコードを作成するには次のように指定する。
親である`insurance`の`year`が2021の場合、2021/04、2021/05、2022/03のレコードが作成される。
（同一会計年度で登録するため。詳細は #96 を参照のこと。）

```ruby
FactoryBot.create(:insurance, :with_payment_target_months, months: [3, 4, 5])
```

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
