### PR TITLE
日本の会計年度で計算できるように設定を追加した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
+gem 'fiscali'
 gem 'kaminari'
 gem 'rails-i18n'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     ffi (1.15.4)
+    fiscali (2.4.4)
+      activesupport
     globalid (1.0.0)
       activesupport (>= 5.0)
     hpricot (0.8.6)
@@ -297,6 +299,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   factory_bot_rails
+  fiscali
   html2slim
   jbuilder (~> 2.7)
   jp_local_gov!

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module Quitcost
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.time_zone = 'Tokyo'
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/fiscali.rb
+++ b/config/initializers/fiscali.rb
@@ -1,0 +1,1 @@
+Time.fiscal_zone = :japan


### PR DESCRIPTION
## 目的

各種料金計算では会計年度での計算が必要になるため、会計年度を扱うための設定を追加する

## やったこと

- Gem: `fiscali`の導入
    - fiscaliのメソッドを経由することで、TimeWithZone（Time、Dateも）に会計年度を扱うためのメソッドが増える
    - 住民税は6月始まりの支払になるが、基本的な日本の会計年度に合わせて4月に設定
- TimeZoneをJapanに設定
    - 日本の税制に則ったアプリなので、日本の時間で設定した。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
