### PR TITLE
給与所得計算機能を作成

### DIFF
--- a/app/models/simulation/salary.rb
+++ b/app/models/simulation/salary.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Simulation::Salary
+  TABLE = {
+    0..550_999 => { plus: 0, multiply: 0, divide: 1 },
+    551_000..1_618_999 => { plus: -550_000, multiply: 1, divide: 1 },
+    1_619_000..1_619_999 => { plus: 1_069_000, multiply: 0, divide: 1 },
+    1_620_000..1_621_999 => { plus: 1_070_000, multiply: 0, divide: 1 },
+    1_622_000..1_623_999 => { plus: 1_072_000, multiply: 0, divide: 1 },
+    1_624_000..1_627_999 => { plus: 1_074_000, multiply: 0, divide: 1 },
+    1_628_000..1_799_999 => { plus: 100_000, multiply: 2.4, divide: 4 },
+    1_800_000..3_599_999 => { plus: -80_000, multiply: 2.8, divide: 4 },
+    3_600_000..6_599_999 => { plus: -440_000, multiply: 3.2, divide: 4 },
+    6_600_000..8_499_999 => { plus: -1_100_000, multiply: 0.9, divide: 1 },
+    8_500_000.. => { plus: -1_950_000, multiply: 1, divide: 1 }
+  }.freeze
+
+  def self.call(income)
+    new(income).call
+  end
+
+  def initialize(income)
+    @income = income
+  end
+
+  def call
+    calculate_salary
+  end
+
+  private
+
+  attr_reader :income
+
+  def calculate_salary
+    value = TABLE.select { |row| row.include?(income) }.values.first
+    base = value[:divide] == 1 ? income : (income / value[:divide]).floor(-3)
+    (base * value[:multiply]).floor + value[:plus]
+  end
+end

--- a/spec/models/simulation/salary_spec.rb
+++ b/spec/models/simulation/salary_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Simulation::Salary, type: :model do
+  # https://www.nta.go.jp/taxes/shiraberu/shinkoku/tebiki/2021/b/03/order2/3-2_06.htm
+  describe '.call' do
+    subject { Simulation::Salary.call(income) }
+
+    context 'whole_income less than 551_000' do # 0
+      let!(:income) { 550_999 }
+      it { is_expected.to eq 0 }
+    end
+
+    context 'whole_income less than 1_619_000' do # income - 550,000
+      context 'whole_income equal to 551_000' do
+        let!(:income) { 551_000 }
+        it { is_expected.to eq 1_000 }
+      end
+
+      context 'whole_income equal to 1_618_999' do
+        let!(:income) { 1_618_999 }
+        it { is_expected.to eq 1_068_999 }
+      end
+    end
+
+    context 'whole_income less than 1_620_000' do # 1,069,000
+      context 'whole_income equal to 1_619_000' do
+        let!(:income) { 1_619_000 }
+        it { is_expected.to eq 1_069_000 }
+      end
+
+      context 'whole_income equal to 1_619_999' do
+        let!(:income) { 1_619_999 }
+        it { is_expected.to eq 1_069_000 }
+      end
+    end
+
+    context 'whole_income less than 1_622_000' do # 1,070,000
+      context 'whole_income equal to 1_620_000' do
+        let!(:income) { 1_620_000 }
+        it { is_expected.to eq 1_070_000 }
+      end
+
+      context 'whole_income equal to 1_621_999' do
+        let!(:income) { 1_621_999 }
+        it { is_expected.to eq 1_070_000 }
+      end
+    end
+
+    context 'whole_income < 1_624_000' do # 1,072,000
+      context 'whole_income equal to 1_622_000' do
+        let!(:income) { 1_622_000 }
+        it { is_expected.to eq 1_072_000 }
+      end
+
+      context 'whole_income equal to 1_623_999' do
+        let!(:income) { 1_623_999 }
+        it { is_expected.to eq 1_072_000 }
+      end
+    end
+
+    context 'whole_income < 1_628_000' do # 1,074,000
+      context 'whole_income equal to 1_624_000' do
+        let!(:income) { 1_624_000 }
+        it { is_expected.to eq 1_074_000 }
+      end
+
+      context 'whole_income equal to 1_627_999' do
+        let!(:income) { 1_627_999 }
+        it { is_expected.to eq 1_074_000 }
+      end
+    end
+
+    context 'whole_income < 1_800_000' do # (income / 4) * 2.4  + 100,000（Rounded down to the nearest 1000 yen）
+      context 'whole_income equal to 1_628_000' do
+        let!(:income) { 1_628_000 }
+        it { is_expected.to eq 1_076_800 }
+      end
+
+      context 'whole_income equal to 1_799_999' do
+        let!(:income) { 1_799_999 }
+        it { is_expected.to eq 1_177_600 }
+      end
+    end
+
+    context 'whole_income < 3_600_000' do # (income / 4) * 2.8  - 80,000（Rounded down to the nearest 1000 yen）
+      context 'whole_income equal to 1_800_000' do
+        let!(:income) { 1_800_000 }
+        it { is_expected.to eq 1_180_000 }
+      end
+
+      context 'whole_income equal to 3_599_999' do
+        let!(:income) { 3_599_999 }
+        it { is_expected.to eq 2_437_200 }
+      end
+    end
+
+    context 'whole_income < 6_600_000' do # (income / 4) * 3.2  - 440,000（Rounded down to the nearest 1000 yen）
+      context 'whole_income equal to 3_600_000' do
+        let!(:income) { 3_600_000 }
+        it { is_expected.to eq 2_440_000 }
+      end
+
+      context 'whole_income equal to 6_599_999' do
+        let!(:income) { 6_599_999 }
+        it { is_expected.to eq 4_836_800 }
+      end
+    end
+
+    context 'whole_income < 8_500_000' do # income * 0.9 - 1,100,000
+      context 'whole_income equal to 6_600_000' do
+        let!(:income) { 6_600_000 }
+        it { is_expected.to eq 4_840_000 }
+      end
+
+      context 'whole_income equal to 8_499_999' do
+        let!(:income) { 8_499_999 }
+        it { is_expected.to eq 6_549_999 }
+      end
+    end
+
+    context 'whole_income >= 8_500_000' do # income - 1,950,000
+      context 'whole_income equal to 8_500_000' do
+        let!(:income) { 8_500_000 }
+        it { is_expected.to eq 6_550_000 }
+      end
+
+      context 'whole_income over 8_500_000' do
+        let!(:income) { 8_500_001 }
+        it { is_expected.to eq 6_550_001 }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 目的

国民健康保険と住民税の計算に必要な、給与所得（所得金額調整控除後）を計算するための処理を作成する。

## やったこと

- 給与所得（所得金額調整控除後）を計算するクラスを実装

## 申し送り事項

- 名前範囲では所得すべてに対して計算を行いそうですが、国民健康保険と住民税では給与所得に対して適用される控除額が異なるため、調整控除のみを適用する責務としています。各計算ごとに異なる控除は、それぞれの計算クラスで適用する想定です。
- 処理自体はテストをパスしていますが、ベタ書き感が否めないので、要リファクタリングです🙏

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
