### PR TITLE
国民年金の計算処理を実装

### DIFF
--- a/app/models/simulation/pension.rb
+++ b/app/models/simulation/pension.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Simulation::Pension
+  def self.call(retirement_month, employment_month)
+    new(retirement_month, employment_month).call
+  end
+
+  def initialize(retirement_month, employment_month)
+    @from = retirement_month
+    @to = employment_month
+  end
+
+  def call
+    calculate_pension
+  end
+
+  private
+
+  attr_reader :from, :to
+
+  def calculate_pension
+    months = Enumerator.produce(from, &:next_month).take_while { |date| date < to }
+    fiscal_years = months.map(&:financial_year).uniq
+    contribution_table = fiscal_years.index_with do |year|
+      query = Pension.exists?(year: year) ? year : Pension.maximum(:year)
+      Pension.find_by(year: query).contribution
+    end
+
+    months.map { |month| { month: month, pension: contribution_table[month.financial_year] } }
+  end
+end

--- a/spec/models/simulation/pension_spec.rb
+++ b/spec/models/simulation/pension_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Simulation::Pension, type: :model do
+  describe '.call' do
+    subject { Simulation::Pension.call(from, to) }
+
+    context 'when Pension record for the specified year is exist' do
+      before do
+        create(:pension, year: 2021, contribution: 16_610)
+        create(:pension, year: 2022, contribution: 16_590)
+      end
+
+      context 'when the calculation period crosses fiscal year' do
+        let!(:from) { Time.zone.parse('2022-03-01') }
+        let!(:to) { Time.zone.parse('2022-05-01') }
+        expected = [
+          { month: Time.zone.parse('2022-03-01'), pension: 16_610 },
+          { month: Time.zone.parse('2022-04-01'), pension: 16_590 }
+        ]
+        it { is_expected.to eq expected }
+      end
+
+      context 'when the calculation period DOES NOT cross fiscal year' do
+        context 'when the calculation period is 1' do
+          let!(:from) { Time.zone.parse('2021-04-01') }
+          let!(:to) { Time.zone.parse('2021-06-01') }
+          expected = [
+            { month: Time.zone.parse('2021-04-01'), pension: 16_610 },
+            { month: Time.zone.parse('2021-05-01'), pension: 16_610 }
+          ]
+          it { is_expected.to eq expected }
+        end
+
+        context 'when the calculation period is 12' do
+          let!(:from) { Time.zone.parse('2021-04-01') }
+          let!(:to) { Time.zone.parse('2022-04-01') }
+          expected = [
+            { month: Time.zone.parse('2021-04-01'), pension: 16_610 },
+            { month: Time.zone.parse('2021-05-01'), pension: 16_610 },
+            { month: Time.zone.parse('2021-06-01'), pension: 16_610 },
+            { month: Time.zone.parse('2021-07-01'), pension: 16_610 },
+            { month: Time.zone.parse('2021-08-01'), pension: 16_610 },
+            { month: Time.zone.parse('2021-09-01'), pension: 16_610 },
+            { month: Time.zone.parse('2021-10-01'), pension: 16_610 },
+            { month: Time.zone.parse('2021-11-01'), pension: 16_610 },
+            { month: Time.zone.parse('2021-12-01'), pension: 16_610 },
+            { month: Time.zone.parse('2022-01-01'), pension: 16_610 },
+            { month: Time.zone.parse('2022-02-01'), pension: 16_610 },
+            { month: Time.zone.parse('2022-03-01'), pension: 16_610 }
+          ]
+          it { is_expected.to eq expected }
+        end
+      end
+    end
+
+    context 'when Pension record for the specified year is NOT exist' do
+      before { create(:pension, year: 2021, contribution: 16_610) }
+
+      context 'when record exists for a year before the specified year' do
+        let!(:from) { Time.zone.parse('2022-04-01') }
+        let!(:to) { Time.zone.parse('2022-06-01') }
+        expected = [
+          { month: Time.zone.parse('2022-04-01'), pension: 16_610 },
+          { month: Time.zone.parse('2022-05-01'), pension: 16_610 }
+        ]
+        it { is_expected.to eq expected }
+      end
+
+      context 'when record DOES NOT exists for a year before the specified year' do
+        let!(:from) { Time.zone.parse('2023-04-01') }
+        let!(:to) { Time.zone.parse('2023-06-01') }
+        expected = [
+          { month: Time.zone.parse('2023-04-01'), pension: 16_610 },
+          { month: Time.zone.parse('2023-05-01'), pension: 16_610 }
+        ]
+        it { is_expected.to eq expected }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 目的

国民年金の計算処理を実装する

## 申し送り事項

- 計算はPensionsテーブルから対象年度のレコードを取得して行います。
- 対象の会計年度の国民年金保険料率のレコードが存在しない場合は、DBに保存されている最大値へフォールバックする仕様です。

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
