### PR TITLE
国民健康保険料の計算処理を実装

### DIFF
--- a/app/models/insurance.rb
+++ b/app/models/insurance.rb
@@ -15,4 +15,20 @@ class Insurance < ApplicationRecord
       end
     end
   end
+
+  def self.rate(year:, local_gov_code:)
+    prefecture_capital_code = JpLocalGov.where(prefecture: JpLocalGov.find(local_gov_code).prefecture, prefecture_capital: true).first.code
+
+    if exists?(year: year, local_gov_code: local_gov_code)
+      find_by(year: year, local_gov_code: local_gov_code)
+    elsif exists?(local_gov_code: local_gov_code)
+      maximum_year = where(local_gov_code: local_gov_code).maximum(:year)
+      find_by(year: maximum_year, local_gov_code: local_gov_code)
+    elsif exists?(year: year, local_gov_code: prefecture_capital_code)
+      find_by(year: year, local_gov_code: prefecture_capital_code)
+    else
+      maximum_year = where(local_gov_code: prefecture_capital_code).maximum(:year)
+      find_by(year: maximum_year, local_gov_code: prefecture_capital_code)
+    end
+  end
 end

--- a/app/models/simulation/insurance.rb
+++ b/app/models/simulation/insurance.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ParameterLists
+
+class Simulation::Insurance
+  def self.call(retirement_month, employment_month, local_gov_code, age, simulation_date, salary, scheduled_salary)
+    new(retirement_month, employment_month, local_gov_code, age, simulation_date, salary, scheduled_salary).call
+  end
+
+  def initialize(retirement_month, employment_month, local_gov_code, age, simulation_date, salary, scheduled_salary)
+    @from = retirement_month
+    @to = employment_month
+    @local_gov_code = local_gov_code
+    @age = age
+    @simulation_date = simulation_date
+    @salary = salary
+    @scheduled_salary = scheduled_salary
+  end
+
+  def call
+    monthly_insurance
+  end
+
+  private
+
+  attr_reader :from, :to, :local_gov_code, :age, :simulation_date, :salary, :scheduled_salary
+
+  def monthly_insurance
+    yearly_insurance.flat_map do |year, fee|
+      payment_target_months = Insurance.rate(year: year, local_gov_code: local_gov_code).payment_target_months
+      payment_terms = payment_terms_by_fiscal_year[year]
+      number_of_payment_duty = months_between(from: payment_terms.first, to: payment_terms.first.end_of_financial_year).count
+      total_fee = fee * number_of_payment_duty / PaymentTargetMonth::CALENDAR.count
+      target_months_in_range = payment_target_months.map(&:month).intersection(payment_terms.map(&:beginning_of_month))
+      remain_dues = payment_target_months.select { |month| month.month >= payment_terms.first }
+      fees_by_month = calculate_fees_by_month(total_fee, remain_dues.count)
+
+      payment_terms.map do |month|
+        insurance = target_months_in_range.include?(month) ? fees_by_month.shift : 0
+        { month: month, insurance: insurance }
+      end
+    end
+  end
+
+  def months_between(from:, to:)
+    Enumerator.produce(from, &:next_month).take_while { |date| date < to }
+  end
+
+  def yearly_insurance
+    result = {}
+    fiscal_years.map do |year|
+      salary = salary_table[year]
+      result[year] = calculate_medical(year, salary) + calculate_elderly(year, salary) + calculate_care(year, salary)
+    end
+    result
+  end
+
+  # NOTE: 前提：フォームで入力可能な「就職月」は`現在日付の会計年度 + 1 の 末月`まで
+  # NOTE: 計算可能な範囲を拡張する場合には、このテーブルに前提に記載の月以降の給与をセットする必要がある
+  def salary_table
+    base_fiscal_year = simulation_date.financial_year
+    {
+      base_fiscal_year => salary,
+      base_fiscal_year + 1 => scheduled_salary
+    }
+  end
+
+  def fiscal_years
+    all_payment_terms.map(&:financial_year).uniq
+  end
+
+  def payment_terms_by_fiscal_year
+    all_payment_terms.group_by(&:financial_year)
+  end
+
+  def all_payment_terms
+    months_between(from: from, to: to)
+  end
+
+  def calculate_medical(year, salary)
+    Simulation::Insurance::Medical.call(year: year, local_gov_code: local_gov_code, income: salary, age: age)
+  end
+
+  def calculate_elderly(year, salary)
+    Simulation::Insurance::Elderly.call(year: year, local_gov_code: local_gov_code, income: salary, age: age)
+  end
+
+  def calculate_care(year, salary)
+    Simulation::Insurance::Care.call(year: year, local_gov_code: local_gov_code, income: salary, age: age)
+  end
+
+  def calculate_fees_by_month(total_fee, number_of_payments)
+    repeat_number = number_of_payments - 1
+    fee_of_not_first_month = (total_fee / number_of_payments).floor(-2)
+    fee_of_first_month = total_fee - fee_of_not_first_month * repeat_number
+    [fee_of_first_month, Array.new(repeat_number) { fee_of_not_first_month }].flatten
+  end
+end
+
+# rubocop:enable Metrics/ParameterLists

--- a/app/models/simulation/insurance/base.rb
+++ b/app/models/simulation/insurance/base.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Simulation::Insurance::Base
+  BASIC_DEDUCTION = 430_000
+
+  def self.call(year:, local_gov_code:, income:, age:)
+    new(year, local_gov_code, income, age).call
+  end
+
+  def initialize(year, local_gov_code, income, age)
+    @income = income
+    @rate = Insurance.rate(year: year, local_gov_code: local_gov_code)
+    @age = age
+  end
+
+  def call
+    calculate
+  end
+
+  private
+
+  attr_reader :rate, :age
+
+  def calculate
+    return 0 if age >= 75
+
+    limit = rate.send("#{name}_limit")
+    calculate_result = income_basis + capita_basis + household_basis
+    calculate_result <= limit ? calculate_result : limit
+  end
+
+  # 所得割
+  def income_basis
+    (salary * rate.send("#{name}_income_basis") / 100).round
+  end
+
+  # 均等割
+  def capita_basis
+    rate.send("#{name}_capita_basis")
+  end
+
+  # 世帯割
+  def household_basis
+    rate.send("#{name}_household_basis")
+  end
+
+  def name
+    self.class.name.demodulize.downcase
+  end
+
+  def salary
+    candidate = Simulation::Salary.call(@income) - BASIC_DEDUCTION
+    candidate.positive? ? candidate : 0
+  end
+end

--- a/app/models/simulation/insurance/care.rb
+++ b/app/models/simulation/insurance/care.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Simulation::Insurance::Care < Simulation::Insurance::Base
+  private
+
+  def calculate
+    return 0 if age < 40 || age >= 65
+
+    super
+  end
+end

--- a/app/models/simulation/insurance/elderly.rb
+++ b/app/models/simulation/insurance/elderly.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class Simulation::Insurance::Elderly < Simulation::Insurance::Base; end

--- a/app/models/simulation/insurance/medical.rb
+++ b/app/models/simulation/insurance/medical.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class Simulation::Insurance::Medical < Simulation::Insurance::Base; end

--- a/spec/models/insurance_spec.rb
+++ b/spec/models/insurance_spec.rb
@@ -18,4 +18,44 @@ RSpec.describe Insurance, type: :model do
       end
     end
   end
+
+  describe '.rate' do
+    subject { Insurance.rate(year: 2022, local_gov_code: '012033') }
+
+    context 'when Insurance for specified year and local government is exist' do
+      before { create(:insurance, year: 2022, local_gov_code: '012033') }
+      it 'returns Insurance record, `year` is specified year and `local_gov_code` is specified code' do
+        expect(subject.year).to eq 2022
+        expect(subject.local_gov_code).to eq '012033'
+      end
+    end
+
+    context 'when Insurance for specified year and local government is NOT exist' do
+      context 'when Insurance for specified local government and other year is exist' do
+        before { create(:insurance, year: 2021, local_gov_code: '012033') }
+        it 'returns Insurance record, `year` is other year and `local_gov_code` is specified code' do
+          expect(subject.year).to eq 2021
+          expect(subject.local_gov_code).to eq '012033'
+        end
+      end
+
+      context 'when Insurance for specified local government is NOT exist' do
+        context 'when Insurance for specified year and prefecture capital of specified local government is exist' do
+          before { create(:insurance, year: 2022, local_gov_code: '011002') }
+          it 'returns Insurance record, `year` is specified year and `local_gov_code` is prefecture capital' do
+            expect(subject.year).to eq 2022
+            expect(subject.local_gov_code).to eq '011002'
+          end
+        end
+
+        context 'when Insurance for specified year and prefecture capital of specified local government is NOT exist' do
+          before { create(:insurance, year: 2021, local_gov_code: '011002') }
+          it 'returns Insurance record, `year` is other year and `local_gov_code` is prefecture capital' do
+            expect(subject.year).to eq 2021
+            expect(subject.local_gov_code).to eq '011002'
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/simulation/insurance/care_spec.rb
+++ b/spec/models/simulation/insurance/care_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Simulation::Insurance::Care, type: :model do
+  describe '.call' do
+    subject { Simulation::Insurance::Care.call(year: year, local_gov_code: local_gov_code, income: income, age: age) }
+    let!(:year) { 2021 }
+    let!(:local_gov_code) { '131016' }
+    let!(:insurance) do
+      create(
+        :insurance,
+        year: 2021,
+        local_gov_code: '131016',
+        care_income_basis: 1.21,
+        care_capita_basis: 14_200,
+        care_household_basis: 10_600,
+        care_limit: 170_000
+      )
+    end
+
+    context 'when age is less than 40' do
+      context 'when age is less than 40' do
+        let!(:age) { 39 }
+        let!(:income) { 14_380_000 }
+        it { is_expected.to eq 0 }
+      end
+    end
+
+    context 'when age is between 40 and 64' do
+      context 'when age is 40' do
+        let!(:age) { 40 }
+        context 'when calculate result is less than care limit' do
+          let!(:income) { 14_379_958 }
+          it { is_expected.to eq 169_999 }
+        end
+
+        context 'when calculate result is care_limit' do
+          let!(:income) { 14_380_000 }
+          it { is_expected.to eq insurance.care_limit }
+        end
+
+        context 'when calculation result is over care_limit' do
+          let!(:income) { 14_380_001 }
+          it { is_expected.to eq insurance.care_limit }
+        end
+      end
+
+      context 'when age is 64' do
+        let!(:age) { 64 }
+        context 'when calculate result is less than care limit' do
+          let!(:income) { 14_379_958 }
+          it { is_expected.to eq 169_999 }
+        end
+
+        context 'when calculate result is care_limit' do
+          let!(:income) { 14_380_000 }
+          it { is_expected.to eq insurance.care_limit }
+        end
+
+        context 'when calculation result is over care_limit' do
+          let!(:income) { 14_380_001 }
+          it { is_expected.to eq insurance.care_limit }
+        end
+      end
+    end
+
+    context 'when age is 65 or more' do
+      let!(:income) { 14_380_000 }
+      context 'age is 65' do
+        let!(:age) { 65 }
+        it { is_expected.to eq 0 }
+      end
+
+      context 'when age is over 65' do
+        let!(:age) { 66 }
+        it { is_expected.to eq 0 }
+      end
+    end
+  end
+end

--- a/spec/models/simulation/insurance/elderly_spec.rb
+++ b/spec/models/simulation/insurance/elderly_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Simulation::Insurance::Elderly, type: :model do
+  describe '.call' do
+    subject { Simulation::Insurance::Elderly.call(year: year, local_gov_code: local_gov_code, income: income, age: age) }
+    let!(:year) { 2021 }
+    let!(:local_gov_code) { '131016' }
+    let!(:insurance) do
+      create(
+        :insurance,
+        year: 2021,
+        local_gov_code: '131016',
+        elderly_income_basis: 2.04,
+        elderly_capita_basis: 11_000,
+        elderly_household_basis: 5_600,
+        elderly_limit: 190_000
+      )
+    end
+
+    context 'when age is less than 75' do
+      let!(:age) { 74 }
+
+      context 'when calculate result is less than elderly limit' do
+        let!(:income) { 10_879_975 }
+        it { is_expected.to eq 189_999 }
+      end
+
+      context 'when calculate result is elderly_limit' do
+        let!(:income) { 10_880_000 }
+        it { is_expected.to eq insurance.elderly_limit }
+      end
+
+      context 'when calculation result is over elderly_limit' do
+        let!(:income) { 10_880_001 }
+        it { is_expected.to eq insurance.elderly_limit }
+      end
+    end
+
+    context 'when age is 75 or more' do
+      let!(:income) { 10_880_000 }
+      context 'age is 75' do
+        let!(:age) { 75 }
+        it { is_expected.to eq 0 }
+      end
+
+      context 'when age is over 75' do
+        let!(:age) { 76 }
+        it { is_expected.to eq 0 }
+      end
+    end
+  end
+end

--- a/spec/models/simulation/insurance/medical_spec.rb
+++ b/spec/models/simulation/insurance/medical_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Simulation::Insurance::Medical, type: :model do
+  describe '.call' do
+    subject { Simulation::Insurance::Medical.call(year: year, local_gov_code: local_gov_code, income: income, age: age) }
+    let!(:year) { 2021 }
+    let!(:local_gov_code) { '131016' }
+    let!(:insurance) do
+      create(
+        :insurance,
+        year: 2021,
+        local_gov_code: '131016',
+        medical_income_basis: 7.25,
+        medical_capita_basis: 37_300,
+        medical_household_basis: 12_700,
+        medical_limit: 630_000
+      )
+    end
+
+    context 'when age is less than 75' do
+      let!(:age) { 74 }
+
+      context 'when calculate result is less than medical limit' do
+        let!(:income) { 10_379_993 }
+        it { is_expected.to eq 629_999 }
+      end
+
+      context 'when calculate result is medical_limit' do
+        let!(:income) { 10_380_000 }
+        it { is_expected.to eq insurance.medical_limit }
+      end
+
+      context 'when calculation result is over medical_limit' do
+        let!(:income) { 10_380_001 }
+        it { is_expected.to eq insurance.medical_limit }
+      end
+    end
+
+    context 'when age is 75 or more' do
+      let!(:income) { 10_380_000 }
+      context 'age is 75' do
+        let!(:age) { 75 }
+        it { is_expected.to eq 0 }
+      end
+
+      context 'when age is over 75' do
+        let!(:age) { 76 }
+        it { is_expected.to eq 0 }
+      end
+    end
+  end
+end

--- a/spec/models/simulation/insurance_spec.rb
+++ b/spec/models/simulation/insurance_spec.rb
@@ -1,0 +1,586 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Simulation::Insurance, type: :model do
+  describe '.call' do
+    subject { Simulation::Insurance.call(retirement_month, employment_month, '131016', 40, simulation_date, salary, scheduled_salary) }
+    # FIXME: 変更する必要がなければ、固定値で呼び出す。
+    let!(:simulation_date) { Time.zone.parse('2021-04-11') }
+    let!(:salary) { 5_000_000 }
+    let!(:scheduled_salary) { 5_000_000 }
+
+    context 'when cross the year before employment' do
+      let!(:retirement_month) { Time.zone.parse('2021-04-01') }
+      let!(:employment_month) { Time.zone.parse('2023-03-01') }
+
+      example '10 term payment(6, 7, 8, 9, 10, 11, 12, 1, 2, 3)' do
+        create(
+          :insurance,
+          :with_payment_target_months,
+          months: [6, 7, 8, 9, 10, 11, 12, 1, 2, 3],
+          year: 2021,
+          local_gov_code: '131016',
+          medical_income_basis: 7.25,
+          medical_capita_basis: 0,
+          medical_household_basis: 37_300,
+          medical_limit: 630_000,
+          elderly_income_basis: 2.04,
+          elderly_capita_basis: 0,
+          elderly_household_basis: 11_000,
+          elderly_limit: 190_000,
+          care_income_basis: 1.21,
+          care_capita_basis: 0,
+          care_household_basis: 14_200,
+          care_limit: 170_000
+        )
+        create(
+          :insurance,
+          :with_payment_target_months,
+          months: [6, 7, 8, 9, 10, 11, 12, 1, 2, 3],
+          year: 2022,
+          local_gov_code: '131016',
+          medical_income_basis: 7.25,
+          medical_capita_basis: 0,
+          medical_household_basis: 37_300,
+          medical_limit: 630_000,
+          elderly_income_basis: 2.04,
+          elderly_capita_basis: 0,
+          elderly_household_basis: 11_000,
+          elderly_limit: 190_000,
+          care_income_basis: 1.21,
+          care_capita_basis: 0,
+          care_household_basis: 14_200,
+          care_limit: 170_000
+        )
+        expected = [
+          { month: Time.zone.parse('2021-04-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-05-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-06-01'), insurance: 39_250 },
+          { month: Time.zone.parse('2021-07-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-08-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-09-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-10-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-11-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-12-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-01-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-02-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-03-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-04-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-05-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-06-01'), insurance: 39_250 },
+          { month: Time.zone.parse('2022-07-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-08-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-09-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-10-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-11-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-12-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2023-01-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2023-02-01'), insurance: 39_100 }
+        ]
+        expect(subject).to eq expected
+      end
+
+      example '10 term payment(4,5,6,7,8,9,10,11,12,1)' do
+        create(
+          :insurance,
+          :with_payment_target_months,
+          months: [4, 5, 6, 7, 8, 9, 10, 11, 12, 1],
+          year: 2021,
+          local_gov_code: '131016',
+          medical_income_basis: 7.25,
+          medical_capita_basis: 0,
+          medical_household_basis: 37_300,
+          medical_limit: 630_000,
+          elderly_income_basis: 2.04,
+          elderly_capita_basis: 0,
+          elderly_household_basis: 11_000,
+          elderly_limit: 190_000,
+          care_income_basis: 1.21,
+          care_capita_basis: 0,
+          care_household_basis: 14_200,
+          care_limit: 170_000
+        )
+        create(
+          :insurance,
+          :with_payment_target_months,
+          months: [4, 5, 6, 7, 8, 9, 10, 11, 12, 1],
+          year: 2022,
+          local_gov_code: '131016',
+          medical_income_basis: 7.25,
+          medical_capita_basis: 0,
+          medical_household_basis: 37_300,
+          medical_limit: 630_000,
+          elderly_income_basis: 2.04,
+          elderly_capita_basis: 0,
+          elderly_household_basis: 11_000,
+          elderly_limit: 190_000,
+          care_income_basis: 1.21,
+          care_capita_basis: 0,
+          care_household_basis: 14_200,
+          care_limit: 170_000
+        )
+        expected = [
+          { month: Time.zone.parse('2021-04-01'), insurance: 39_250 },
+          { month: Time.zone.parse('2021-05-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-06-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-07-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-08-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-09-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-10-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-11-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-12-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-01-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-02-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-03-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-04-01'), insurance: 39_250 },
+          { month: Time.zone.parse('2022-05-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-06-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-07-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-08-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-09-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-10-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-11-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-12-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2023-01-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2023-02-01'), insurance: 0 }
+        ]
+        expect(subject).to eq expected
+      end
+
+      example '4 term payment(1,7,9,11)' do
+        create(
+          :insurance,
+          :with_payment_target_months,
+          months: [1, 7, 9, 11],
+          year: 2021,
+          local_gov_code: '131016',
+          medical_income_basis: 7.25,
+          medical_capita_basis: 0,
+          medical_household_basis: 37_300,
+          medical_limit: 630_000,
+          elderly_income_basis: 2.04,
+          elderly_capita_basis: 0,
+          elderly_household_basis: 11_000,
+          elderly_limit: 190_000,
+          care_income_basis: 1.21,
+          care_capita_basis: 0,
+          care_household_basis: 14_200,
+          care_limit: 170_000
+        )
+        create(
+          :insurance,
+          :with_payment_target_months,
+          months: [1, 7, 9, 11],
+          year: 2022,
+          local_gov_code: '131016',
+          medical_income_basis: 7.25,
+          medical_capita_basis: 0,
+          medical_household_basis: 37_300,
+          medical_limit: 630_000,
+          elderly_income_basis: 2.04,
+          elderly_capita_basis: 0,
+          elderly_household_basis: 11_000,
+          elderly_limit: 190_000,
+          care_income_basis: 1.21,
+          care_capita_basis: 0,
+          care_household_basis: 14_200,
+          care_limit: 170_000
+        )
+        expected = [
+          { month: Time.zone.parse('2021-04-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-05-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-06-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-07-01'), insurance: 98_050 },
+          { month: Time.zone.parse('2021-08-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-09-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2021-10-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-11-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2021-12-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-01-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2022-02-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-03-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-04-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-05-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-06-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-07-01'), insurance: 98_050 },
+          { month: Time.zone.parse('2022-08-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-09-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2022-10-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-11-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2022-12-01'), insurance: 0 },
+          { month: Time.zone.parse('2023-01-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2023-02-01'), insurance: 0 }
+        ]
+        expect(subject).to eq expected
+      end
+
+      example '4 term payment(7,9,10,12)' do
+        create(
+          :insurance,
+          :with_payment_target_months,
+          months: [7, 9, 10, 12],
+          year: 2021,
+          local_gov_code: '131016',
+          medical_income_basis: 7.25,
+          medical_capita_basis: 0,
+          medical_household_basis: 37_300,
+          medical_limit: 630_000,
+          elderly_income_basis: 2.04,
+          elderly_capita_basis: 0,
+          elderly_household_basis: 11_000,
+          elderly_limit: 190_000,
+          care_income_basis: 1.21,
+          care_capita_basis: 0,
+          care_household_basis: 14_200,
+          care_limit: 170_000
+        )
+        create(
+          :insurance,
+          :with_payment_target_months,
+          months: [7, 9, 10, 12],
+          year: 2022,
+          local_gov_code: '131016',
+          medical_income_basis: 7.25,
+          medical_capita_basis: 0,
+          medical_household_basis: 37_300,
+          medical_limit: 630_000,
+          elderly_income_basis: 2.04,
+          elderly_capita_basis: 0,
+          elderly_household_basis: 11_000,
+          elderly_limit: 190_000,
+          care_income_basis: 1.21,
+          care_capita_basis: 0,
+          care_household_basis: 14_200,
+          care_limit: 170_000
+        )
+        expected = [
+          { month: Time.zone.parse('2021-04-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-05-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-06-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-07-01'), insurance: 98_050 },
+          { month: Time.zone.parse('2021-08-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-09-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2021-10-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2021-11-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-12-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2022-01-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-02-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-03-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-04-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-05-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-06-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-07-01'), insurance: 98_050 },
+          { month: Time.zone.parse('2022-08-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-09-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2022-10-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2022-11-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-12-01'), insurance: 97_700 },
+          { month: Time.zone.parse('2023-01-01'), insurance: 0 },
+          { month: Time.zone.parse('2023-02-01'), insurance: 0 }
+        ]
+        expect(subject).to eq expected
+      end
+    end
+
+    context 'when DO NOT cross the year before employment' do
+      context 'when get a job in this financial year' do
+        let!(:retirement_month) { Time.zone.parse('2021-04-01') }
+        let!(:employment_month) { Time.zone.parse('2022-03-01') }
+
+        example '10 term payment(6,7,8,9,10,11,12,1,2,3)' do
+          create(
+            :insurance,
+            :with_payment_target_months,
+            months: [6, 7, 8, 9, 10, 11, 12, 1, 2, 3],
+            year: 2021,
+            local_gov_code: '131016',
+            medical_income_basis: 7.25,
+            medical_capita_basis: 0,
+            medical_household_basis: 37_300,
+            medical_limit: 630_000,
+            elderly_income_basis: 2.04,
+            elderly_capita_basis: 0,
+            elderly_household_basis: 11_000,
+            elderly_limit: 190_000,
+            care_income_basis: 1.21,
+            care_capita_basis: 0,
+            care_household_basis: 14_200,
+            care_limit: 170_000
+          )
+          expected = [
+            { month: Time.zone.parse('2021-04-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-05-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-06-01'), insurance: 39_250 },
+            { month: Time.zone.parse('2021-07-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-08-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-09-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-10-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-11-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-12-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-01-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-02-01'), insurance: 39_100 }
+          ]
+          expect(subject).to eq expected
+        end
+
+        example '10 term payment(4,5,6,7,8,9,10,11,12,1)' do
+          create(
+            :insurance,
+            :with_payment_target_months,
+            months: [4, 5, 6, 7, 8, 9, 10, 11, 12, 1],
+            year: 2021,
+            local_gov_code: '131016',
+            medical_income_basis: 7.25,
+            medical_capita_basis: 0,
+            medical_household_basis: 37_300,
+            medical_limit: 630_000,
+            elderly_income_basis: 2.04,
+            elderly_capita_basis: 0,
+            elderly_household_basis: 11_000,
+            elderly_limit: 190_000,
+            care_income_basis: 1.21,
+            care_capita_basis: 0,
+            care_household_basis: 14_200,
+            care_limit: 170_000
+          )
+          expected = [
+            { month: Time.zone.parse('2021-04-01'), insurance: 39_250 },
+            { month: Time.zone.parse('2021-05-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-06-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-07-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-08-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-09-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-10-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-11-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2021-12-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-01-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-02-01'), insurance: 0 }
+          ]
+          expect(subject).to eq expected
+        end
+
+        example '4 term payment(1,7,9,11)' do
+          create(
+            :insurance,
+            :with_payment_target_months,
+            months: [1, 7, 9, 11],
+            year: 2021,
+            local_gov_code: '131016',
+            medical_income_basis: 7.25,
+            medical_capita_basis: 0,
+            medical_household_basis: 37_300,
+            medical_limit: 630_000,
+            elderly_income_basis: 2.04,
+            elderly_capita_basis: 0,
+            elderly_household_basis: 11_000,
+            elderly_limit: 190_000,
+            care_income_basis: 1.21,
+            care_capita_basis: 0,
+            care_household_basis: 14_200,
+            care_limit: 170_000
+          )
+          expected = [
+            { month: Time.zone.parse('2021-04-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-05-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-06-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-07-01'), insurance: 98_050 },
+            { month: Time.zone.parse('2021-08-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-09-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2021-10-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-11-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2021-12-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-01-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2022-02-01'), insurance: 0 }
+          ]
+          expect(subject).to eq expected
+        end
+
+        example '4 term payment(7,9,10,12)' do
+          create(
+            :insurance,
+            :with_payment_target_months,
+            months: [7, 9, 10, 12],
+            year: 2021,
+            local_gov_code: '131016',
+            medical_income_basis: 7.25,
+            medical_capita_basis: 0,
+            medical_household_basis: 37_300,
+            medical_limit: 630_000,
+            elderly_income_basis: 2.04,
+            elderly_capita_basis: 0,
+            elderly_household_basis: 11_000,
+            elderly_limit: 190_000,
+            care_income_basis: 1.21,
+            care_capita_basis: 0,
+            care_household_basis: 14_200,
+            care_limit: 170_000
+          )
+          expected = [
+            { month: Time.zone.parse('2021-04-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-05-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-06-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-07-01'), insurance: 98_050 },
+            { month: Time.zone.parse('2021-08-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-09-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2021-10-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2021-11-01'), insurance: 0 },
+            { month: Time.zone.parse('2021-12-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2022-01-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-02-01'), insurance: 0 }
+          ]
+          expect(subject).to eq expected
+        end
+      end
+
+      context 'when retire and get a job in the next financial year' do
+        let!(:retirement_month) { Time.zone.parse('2022-04-01') }
+        let!(:employment_month) { Time.zone.parse('2023-03-01') }
+
+        example '10 term payment(6,7,8,9,10,11,12,1,2,3)' do
+          create(
+            :insurance,
+            :with_payment_target_months,
+            months: [6, 7, 8, 9, 10, 11, 12, 1, 2, 3],
+            year: 2022,
+            local_gov_code: '131016',
+            medical_income_basis: 7.25,
+            medical_capita_basis: 0,
+            medical_household_basis: 37_300,
+            medical_limit: 630_000,
+            elderly_income_basis: 2.04,
+            elderly_capita_basis: 0,
+            elderly_household_basis: 11_000,
+            elderly_limit: 190_000,
+            care_income_basis: 1.21,
+            care_capita_basis: 0,
+            care_household_basis: 14_200,
+            care_limit: 170_000
+          )
+          expected = [
+            { month: Time.zone.parse('2022-04-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-05-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-06-01'), insurance: 39_250 },
+            { month: Time.zone.parse('2022-07-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-08-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-09-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-10-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-11-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-12-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2023-01-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2023-02-01'), insurance: 39_100 }
+          ]
+          expect(subject).to eq expected
+        end
+
+        example '10 term payment(4,5,6,7,8,9,10,11,12,1)' do
+          create(
+            :insurance,
+            :with_payment_target_months,
+            months: [4, 5, 6, 7, 8, 9, 10, 11, 12, 1],
+            year: 2022,
+            local_gov_code: '131016',
+            medical_income_basis: 7.25,
+            medical_capita_basis: 0,
+            medical_household_basis: 37_300,
+            medical_limit: 630_000,
+            elderly_income_basis: 2.04,
+            elderly_capita_basis: 0,
+            elderly_household_basis: 11_000,
+            elderly_limit: 190_000,
+            care_income_basis: 1.21,
+            care_capita_basis: 0,
+            care_household_basis: 14_200,
+            care_limit: 170_000
+          )
+          expected = [
+            { month: Time.zone.parse('2022-04-01'), insurance: 39_250 },
+            { month: Time.zone.parse('2022-05-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-06-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-07-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-08-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-09-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-10-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-11-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2022-12-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2023-01-01'), insurance: 39_100 },
+            { month: Time.zone.parse('2023-02-01'), insurance: 0 }
+          ]
+          expect(subject).to eq expected
+        end
+
+        example '4 term payment(1,7,9,11)' do
+          create(
+            :insurance,
+            :with_payment_target_months,
+            months: [1, 7, 9, 11],
+            year: 2022,
+            local_gov_code: '131016',
+            medical_income_basis: 7.25,
+            medical_capita_basis: 0,
+            medical_household_basis: 37_300,
+            medical_limit: 630_000,
+            elderly_income_basis: 2.04,
+            elderly_capita_basis: 0,
+            elderly_household_basis: 11_000,
+            elderly_limit: 190_000,
+            care_income_basis: 1.21,
+            care_capita_basis: 0,
+            care_household_basis: 14_200,
+            care_limit: 170_000
+          )
+          expected = [
+            { month: Time.zone.parse('2022-04-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-05-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-06-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-07-01'), insurance: 98_050 },
+            { month: Time.zone.parse('2022-08-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-09-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2022-10-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-11-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2022-12-01'), insurance: 0 },
+            { month: Time.zone.parse('2023-01-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2023-02-01'), insurance: 0 }
+          ]
+          expect(subject).to eq expected
+        end
+
+        example '4 term payment(7,9,10,12)' do
+          create(
+            :insurance,
+            :with_payment_target_months,
+            months: [7, 9, 10, 12],
+            year: 2022,
+            local_gov_code: '131016',
+            medical_income_basis: 7.25,
+            medical_capita_basis: 0,
+            medical_household_basis: 37_300,
+            medical_limit: 630_000,
+            elderly_income_basis: 2.04,
+            elderly_capita_basis: 0,
+            elderly_household_basis: 11_000,
+            elderly_limit: 190_000,
+            care_income_basis: 1.21,
+            care_capita_basis: 0,
+            care_household_basis: 14_200,
+            care_limit: 170_000
+          )
+          expected = [
+            { month: Time.zone.parse('2022-04-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-05-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-06-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-07-01'), insurance: 98_050 },
+            { month: Time.zone.parse('2022-08-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-09-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2022-10-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2022-11-01'), insurance: 0 },
+            { month: Time.zone.parse('2022-12-01'), insurance: 97_700 },
+            { month: Time.zone.parse('2023-01-01'), insurance: 0 },
+            { month: Time.zone.parse('2023-02-01'), insurance: 0 }
+          ]
+          expect(subject).to eq expected
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 目的

- 国民健康保険の計算処理を実装する

## 申し送り事項

- 計算に利用する値はInsurancesテーブルから、次の順序で取得します
    1. 対象年度、対象市区町村の値でレコードを取得する
    1. 対象市区町村のもっとも大きい年度のレコードを取得する
    1. 対象市区町村の都道府県庁所在地の、対象年度のレコードを取得する
    1. 対象市区町村の都道府県庁所在地の、もっとも大きい年度のレコードを取得する
-  前提として、フォームで入力可能な「就職月」は`現在日付の会計年度 + 1 の 末月`までとしています

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
