### PR TITLE
feat(simulation::residence): 住民税計算機能を実装

### DIFF
--- a/app/models/simulation/residence.rb
+++ b/app/models/simulation/residence.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/ParameterLists
+
+class Simulation::Residence
+  BASIC_DEDUCTION = 430_000
+  PREFECTURE_CAPITA_BASIS = 1_500
+  CITY_CAPITA_BASIS = 3_500
+  PREFECTURE_TAX_DEDUCTION = 1_000
+  CITY_TAX_DEDUCTION = 1_500
+  PREFECTURE_TAX_RATE = 4
+  CITY_TAX_RATE = 6
+  DUES = [6, 8, 10, 1].freeze
+  NON_TAXABLE_SALARY_LIMIT = 1_000_000
+
+  def self.call(retirement_month, employment_month, salary, social_insurance, scheduled_salary, scheduled_social_insurance, simulation_date)
+    new(retirement_month, employment_month, salary, social_insurance, scheduled_salary, scheduled_social_insurance, simulation_date).call
+  end
+
+  def initialize(retirement_month, employment_month, salary, social_insurance, scheduled_salary, scheduled_social_insurance, simulation_date)
+    @from = retirement_month
+    @to = employment_month
+    @salary = salary
+    @social_insurance = social_insurance
+    @scheduled_salary = scheduled_salary
+    @scheduled_social_insurance = scheduled_social_insurance
+    @simulation_date = simulation_date
+  end
+
+  def call
+    monthly_residence
+  end
+
+  private
+
+  attr_reader :from, :to, :salary, :social_insurance, :scheduled_salary, :scheduled_social_insurance, :simulation_date
+
+  def monthly_residence
+    fiscal_years.flat_map do |year|
+      payment_terms = payment_terms_by_fiscal_year[year]
+      beginning_of_terms = payment_terms.first
+      elapsed_month = months_between(from: beginning_of_terms.beginning_of_financial_year.next_month.next_month, to: beginning_of_terms)
+      unpaid_fee = calc_special_collection(yearly_residence(year)).drop(elapsed_month.count).sum
+      remain_dues = DUES.map { |month| convert_time(year, month) }.select { |month| month >= beginning_of_terms }
+      due_months = remain_dues.empty? ? [beginning_of_terms] : remain_dues
+      fees_by_month = calculate_fees_by_month(unpaid_fee, due_months.count)
+      payment_terms.map { |month| { month: month, residence: due_months.include?(month) ? fees_by_month.shift : 0 } }
+    end
+  end
+
+  def convert_time(year, month)
+    Time.zone.parse("#{month >= 4 ? year : year.next}-#{format('%02d', month)}-01")
+  end
+
+  def months_between(from:, to:)
+    Enumerator.produce(from, &:next_month).take_while { |date| date < to }
+  end
+
+  def calc_special_collection(yearly_residence)
+    calculate_fees_by_month(yearly_residence, 12)
+  end
+
+  def calculate_fees_by_month(total_fee, number_of_payments)
+    repeat_number = number_of_payments - 1
+    fee_of_not_first_month = (total_fee / number_of_payments).floor(-2)
+    fee_of_first_month = total_fee - fee_of_not_first_month * repeat_number
+    [fee_of_first_month, Array.new(repeat_number) { fee_of_not_first_month }].flatten
+  end
+
+  def fiscal_years
+    all_payment_terms.map { |payment_term| payment_term.prev_month.prev_month.financial_year }.uniq
+  end
+
+  def payment_terms_by_fiscal_year
+    all_payment_terms.group_by { |payment_term| payment_term.prev_month.prev_month.financial_year }
+  end
+
+  def all_payment_terms
+    months_between(from: from, to: to)
+  end
+
+  def yearly_residence(year)
+    return 0 if salary_table[year] <= NON_TAXABLE_SALARY_LIMIT
+
+    income_basis(year) + capita_basis
+  end
+
+  def income_basis(year)
+    income_basis_before_tax_apply(year) - tax_deduction
+  end
+
+  def capita_basis
+    PREFECTURE_CAPITA_BASIS + CITY_CAPITA_BASIS
+  end
+
+  def tax_deduction
+    PREFECTURE_TAX_DEDUCTION + CITY_TAX_DEDUCTION
+  end
+
+  def income_basis_before_tax_apply(year)
+    tax_rates.map { |tax_rate| (taxation_total_income(year) * tax_rate / 100).floor(-2) }.sum
+  end
+
+  def tax_rates
+    [PREFECTURE_TAX_RATE, CITY_TAX_RATE]
+  end
+
+  def taxation_total_income(year)
+    (total_income(year) - income_deduction(year)).floor(-3)
+  end
+
+  def total_income(year)
+    Simulation::Salary.call(salary_table[year])
+  end
+
+  def income_deduction(year)
+    social_insurance_table[year] + BASIC_DEDUCTION
+  end
+
+  def salary_table
+    {
+      base_fiscal_year => salary,
+      base_fiscal_year.next => scheduled_salary
+    }
+  end
+
+  def social_insurance_table
+    {
+      base_fiscal_year => social_insurance,
+      base_fiscal_year.next => scheduled_social_insurance
+    }
+  end
+
+  def base_fiscal_year
+    simulation_date.financial_year
+  end
+end
+
+# rubocop:enable Metrics/ClassLength
+# rubocop:enable Metrics/ParameterLists

--- a/spec/models/simulation/residence_spec.rb
+++ b/spec/models/simulation/residence_spec.rb
@@ -1,0 +1,667 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Simulation::Residence, type: :model do
+  describe '.call' do
+    subject do
+      Simulation::Residence.call(retirement_month, employment_month, salary, social_insurance, scheduled_salary, scheduled_social_insurance, simulation_date)
+    end
+
+    let!(:simulation_date) { Time.zone.parse('2021-04-11') }
+
+    context '給与収入が1,000,000より大きい場合' do
+      let!(:salary) { 4_988_682 }
+      let!(:social_insurance) { 736_489 }
+      let!(:scheduled_salary) { 3_000_000 }
+      let!(:scheduled_social_insurance) { 500_000 }
+      context '年度の途中で退職し、年度のおわりまで無職でいる場合' do
+        context '現在日付の年度で退職し、その年度のおわりまで無職でいる場合' do
+          context '1-5月に退職する場合' do
+            let!(:retirement_month) { Time.zone.parse('2022-02-01') }
+            let!(:employment_month) { Time.zone.parse('2022-06-01') }
+
+            it '該当年度の1月~5月分の特別徴収額が、退職月に一括請求されること' do
+              expected = [
+                { month: Time.zone.parse('2022-02-01'), residence: 80_000 },
+                { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                { month: Time.zone.parse('2022-05-01'), residence: 0 }
+              ]
+              expect(subject).to eq expected
+            end
+          end
+
+          context '6~12月に退職する場合' do
+            let!(:employment_month) { Time.zone.parse('2022-06-01') }
+
+            context '第1期（6月）に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-06-01') }
+
+              it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になること' do
+                expected = [
+                  { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                  { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-05-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+
+            context '第2期（8月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-07-01') }
+
+              it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になること' do
+                expected = [
+                  { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                  { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+                  { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 73_300 },
+                  { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-05-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+
+            context '第3期（10月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-09-01') }
+
+              it '該当年度の退職~5月分の特別徴収額が、10月と1月で分納になること' do
+                expected = [
+                  { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 90_000 },
+                  { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 90_000 },
+                  { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-05-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+
+            context '第4期（1月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-12-01') }
+
+              it '該当年度の退職~5月の特別徴収分が、1月に支払になること' do
+                expected = [
+                  { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 120_000 },
+                  { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-05-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+          end
+        end
+
+        context '現在日付の年度で退職し、翌年度のおわりまで無職でいる場合' do
+          # 翌年度は国民健康保険料の都合上、3月分までしか表示できない（=翌々年度の4月に就職が制限）。
+          context '1~5月に退職する場合' do
+            let!(:retirement_month) { Time.zone.parse('2022-02-01') }
+            let!(:employment_month) { Time.zone.parse('2023-04-01') }
+
+            it '該当年度の1月~5月分の特別徴収額が退職月に一括請求され、翌年度の住民税が普通徴収されること' do
+              expected = [
+                { month: Time.zone.parse('2022-02-01'), residence: 80_000 },
+                { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                { month: Time.zone.parse('2022-05-01'), residence: 0 },
+                { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                { month: Time.zone.parse('2022-07-01'), residence: 0 },
+                { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                { month: Time.zone.parse('2022-09-01'), residence: 0 },
+                { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                { month: Time.zone.parse('2022-11-01'), residence: 0 },
+                { month: Time.zone.parse('2022-12-01'), residence: 0 },
+                { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                { month: Time.zone.parse('2023-02-01'), residence: 0 },
+                { month: Time.zone.parse('2023-03-01'), residence: 0 }
+              ]
+              expect(subject).to eq expected
+            end
+          end
+
+          context '6~12月に退職する場合' do
+            let!(:employment_month) { Time.zone.parse('2023-04-01') }
+
+            context '第1期（6月）に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-06-01') }
+
+              it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になること、翌年度の住民税が普通徴収されること' do
+                expected = [
+                  { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                  { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-05-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-03-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+
+            context '第2期（8月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-07-01') }
+
+              it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になること、翌年度の住民税が普通徴収されること' do
+                expected = [
+                  { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                  { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+                  { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 73_300 },
+                  { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-05-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-03-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+
+            context '第3期（10月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-09-01') }
+
+              it '該当年度の退職~5月分の特別徴収額が、10月と1月で分納になること、翌年度の住民税が普通徴収されること' do
+                expected = [
+                  { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 90_000 },
+                  { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 90_000 },
+                  { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-05-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-03-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+
+            context '第4期（1月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-12-01') }
+
+              it '該当年度の退職~5月分の特別徴収分が、1月に支払になること、翌年度の住民税が普通徴収されること' do
+                expected = [
+                  { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 120_000 },
+                  { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-05-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-03-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+          end
+        end
+
+        context '現在日付の翌年度の途中で退職し、その年度のおわりまで無職でいる場合' do
+          # 翌年度は国民健康保険料の都合上、3月分までしか表示できない（=翌々年度の4月に就職が制限）。
+          context '1~5月に退職する場合' do
+            let!(:retirement_month) { Time.zone.parse('2023-02-01') }
+            let!(:employment_month) { Time.zone.parse('2023-04-01') }
+
+            it '該当年度の1月~5月分の特別徴収額が、退職月に一括請求されること' do
+              expected = [
+                { month: Time.zone.parse('2023-02-01'), residence: 36_800 },
+                { month: Time.zone.parse('2023-03-01'), residence: 0 }
+              ]
+              expect(subject).to eq expected
+            end
+          end
+
+          context '6~12月に退職する場合' do
+            let!(:employment_month) { Time.zone.parse('2023-04-01') }
+
+            context '第1期（6月）に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2022-06-01') }
+
+              it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になること' do
+                expected = [
+                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-03-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+
+            context '第2期（8月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2022-07-01') }
+
+              it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になること' do
+                expected = [
+                  { month: Time.zone.parse('2022-07-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 33_800 },
+                  { month: Time.zone.parse('2022-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 33_700 },
+                  { month: Time.zone.parse('2022-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 33_700 },
+                  { month: Time.zone.parse('2023-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-03-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+
+            context '第3期（10月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2022-09-01') }
+
+              it '該当年度の退職~5月分の特別徴収額が、10月と1月で分納になること' do
+                expected = [
+                  { month: Time.zone.parse('2022-09-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 41_400 },
+                  { month: Time.zone.parse('2022-11-01'), residence: 0 },
+                  { month: Time.zone.parse('2022-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 41_400 },
+                  { month: Time.zone.parse('2023-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-03-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+
+            context '第4期（1月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2022-12-01') }
+
+              it '該当年度の退職~5月の特別徴収分が、1月に支払になること' do
+                expected = [
+                  { month: Time.zone.parse('2022-12-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 55_200 },
+                  { month: Time.zone.parse('2023-02-01'), residence: 0 },
+                  { month: Time.zone.parse('2023-03-01'), residence: 0 }
+                ]
+                expect(subject).to eq expected
+              end
+            end
+          end
+        end
+      end
+
+      context '年度の途中で退職し、年度の途中で就職する場合' do
+        context '現在日付の年度で退職し、その年度の途中で就職する場合' do
+          context '1~5月に退職する場合' do
+            let!(:retirement_month) { Time.zone.parse('2022-02-01') }
+            let!(:employment_month) { Time.zone.parse('2022-04-01') }
+
+            it '該当年度の1~5月分の特別徴収額が、退職月に一括請求されること' do
+              # 退職したタイミングでは「いつ就職するか」はわからないため、問答無用で一括請求される
+              expected = [
+                { month: Time.zone.parse('2022-02-01'), residence: 80_000 },
+                { month: Time.zone.parse('2022-03-01'), residence: 0 }
+              ]
+              expect(subject).to eq expected
+            end
+          end
+
+          context '6~12月に退職する場合' do
+            context '第1期（6月）に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-06-01') }
+
+              # 就職月は退職月の翌月以降に制限するので、6月にやめて6月に転職するケースはない
+              context '第2期（8月）以前に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2021-08-01') }
+
+                it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になり、6月のみ支払対象とすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                    { month: Time.zone.parse('2021-07-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+
+              context '第3期（10月)以前に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2021-10-01') }
+
+                it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になり、6、8月分を支払対象とすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                    { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-09-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+
+              context '第4期（1月)以前に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2022-01-01') }
+
+                it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になり、6、8、10月分を支払対象とすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                    { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-12-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+
+              context '第4期よりあと（2~5月）に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2022-05-01') }
+
+                it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になり、6、8、10、1月分を支払対象とすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                    { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-01-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-04-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+            end
+
+            context '第2期（8月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-07-01') }
+
+              # 7月にやめて8月に就職するケース
+              context '第2期（8月）以前に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2021-08-01') }
+
+                it '支払いが発生しないこと' do
+                  expected = [
+                    { month: Time.zone.parse('2021-07-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+
+              context '第3期（10月)以前に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2021-10-01') }
+
+                it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になり、8月分を支払対象とすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                    { month: Time.zone.parse('2021-09-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+
+              context '第4期（1月)以前に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2022-01-01') }
+
+                it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になり、8、10月分を支払対象とすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                    { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+                    { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-12-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+
+              context '第4期よりあと（2~5月）に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2022-05-01') }
+
+                it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になり、8、10、1月分を支払対象とすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-07-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                    { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+                    { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-01-01'), residence: 73_300 },
+                    { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-04-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+            end
+
+            context '第3期（10月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-09-01') }
+
+              # 9月に退職して、10月に就職するケース
+              context '第3期（10月)以前に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2021-10-01') }
+
+                it '支払いが発生しないこと' do
+                  expected = [
+                    { month: Time.zone.parse('2021-09-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+
+              context '第4期（1月)以前に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2022-01-01') }
+
+                it '該当年度の退職~5月分の特別徴収額が、10,1月で分納になり、10月分を支払対象とすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 90_000 },
+                    { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-12-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+
+              context '第4期よりあと（2~5月）に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2022-05-01') }
+
+                it '該当年度の退職~5月分の特別徴収額が、10,1月で分納になり、1月分を支払対象とすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-09-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 90_000 },
+                    { month: Time.zone.parse('2021-11-01'), residence: 0 },
+                    { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-01-01'), residence: 90_000 },
+                    { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-04-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+            end
+
+            context '第4期（1月）以前に退職する場合' do
+              let!(:retirement_month) { Time.zone.parse('2021-12-01') }
+
+              context '第4期（1月)以前に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2022-01-01') }
+
+                it '支払いが発生しないこと' do
+                  expected = [
+                    { month: Time.zone.parse('2021-12-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+
+              context '第4期よりあと（2~5月）に就職する場合' do
+                let!(:employment_month) { Time.zone.parse('2022-05-01') }
+
+                it '該当年度の退職~5月分の特別徴収額を1月支払いとすること' do
+                  expected = [
+                    { month: Time.zone.parse('2021-12-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-01-01'), residence: 120_000 },
+                    { month: Time.zone.parse('2022-02-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-03-01'), residence: 0 },
+                    { month: Time.zone.parse('2022-04-01'), residence: 0 }
+                  ]
+                  expect(subject).to eq expected
+                end
+              end
+            end
+          end
+        end
+
+        context '現在日付の年度で退職し、翌年度の途中で就職する場合' do
+          let!(:retirement_month) { Time.zone.parse('2021-07-01') }
+          let!(:employment_month) { Time.zone.parse('2022-07-01') }
+
+          it '退職年度の金額が普通徴収として残りの納期に按分され、翌年度の料金は普通徴収として計算した上で就職する前月まで支払義務が発生すること' do
+            expected = [
+              { month: Time.zone.parse('2021-07-01'), residence: 0 },
+              { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+              { month: Time.zone.parse('2021-09-01'), residence: 0 },
+              { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+              { month: Time.zone.parse('2021-11-01'), residence: 0 },
+              { month: Time.zone.parse('2021-12-01'), residence: 0 },
+              { month: Time.zone.parse('2022-01-01'), residence: 73_300 },
+              { month: Time.zone.parse('2022-02-01'), residence: 0 },
+              { month: Time.zone.parse('2022-03-01'), residence: 0 },
+              { month: Time.zone.parse('2022-04-01'), residence: 0 },
+              { month: Time.zone.parse('2022-05-01'), residence: 0 },
+              { month: Time.zone.parse('2022-06-01'), residence: 28_100 }
+            ]
+            expect(subject).to eq expected
+          end
+        end
+
+        context '現在日付の翌年度の途中で退職し、その年度の途中で就職する場合' do
+          let!(:retirement_month) { Time.zone.parse('2022-07-01') }
+          let!(:employment_month) { Time.zone.parse('2022-11-01') }
+
+          it '退職年度の金額が普通徴収として残りの納期に按分され、翌年度の料金は普通徴収として計算した上で就職する前月まで支払義務が発生すること' do
+            expected = [
+              { month: Time.zone.parse('2022-07-01'), residence: 0 },
+              { month: Time.zone.parse('2022-08-01'), residence: 33_800 },
+              { month: Time.zone.parse('2022-09-01'), residence: 0 },
+              { month: Time.zone.parse('2022-10-01'), residence: 33_700 }
+            ]
+            expect(subject).to eq expected
+          end
+        end
+      end
+    end
+
+    context '給与収入が1,000,000以下の場合' do
+      let!(:salary) { 0 }
+      let!(:social_insurance) { 0 }
+      let!(:scheduled_salary) { 0 }
+      let!(:scheduled_social_insurance) { 0 }
+      let!(:retirement_month) { Time.zone.parse('2021-06-01') }
+      let!(:employment_month) { Time.zone.parse('2023-04-01') }
+
+      it '所得税が（所得割、均等割ともに）0になること' do
+        expected = [
+          { month: Time.zone.parse('2021-06-01'), residence: 0 },
+          { month: Time.zone.parse('2021-07-01'), residence: 0 },
+          { month: Time.zone.parse('2021-08-01'), residence: 0 },
+          { month: Time.zone.parse('2021-09-01'), residence: 0 },
+          { month: Time.zone.parse('2021-10-01'), residence: 0 },
+          { month: Time.zone.parse('2021-11-01'), residence: 0 },
+          { month: Time.zone.parse('2021-12-01'), residence: 0 },
+          { month: Time.zone.parse('2022-01-01'), residence: 0 },
+          { month: Time.zone.parse('2022-02-01'), residence: 0 },
+          { month: Time.zone.parse('2022-03-01'), residence: 0 },
+          { month: Time.zone.parse('2022-04-01'), residence: 0 },
+          { month: Time.zone.parse('2022-05-01'), residence: 0 },
+          { month: Time.zone.parse('2022-06-01'), residence: 0 },
+          { month: Time.zone.parse('2022-07-01'), residence: 0 },
+          { month: Time.zone.parse('2022-08-01'), residence: 0 },
+          { month: Time.zone.parse('2022-09-01'), residence: 0 },
+          { month: Time.zone.parse('2022-10-01'), residence: 0 },
+          { month: Time.zone.parse('2022-11-01'), residence: 0 },
+          { month: Time.zone.parse('2022-12-01'), residence: 0 },
+          { month: Time.zone.parse('2023-01-01'), residence: 0 },
+          { month: Time.zone.parse('2023-02-01'), residence: 0 },
+          { month: Time.zone.parse('2023-03-01'), residence: 0 }
+        ]
+        expect(subject).to eq expected
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 目的

- 住民税計算処理を実装する

## 申し送り事項

- 非課税限度額について、実際のルールとしては地方自治体によって微妙に異なる部分もあるが、現時点では各自治体で多数派である100万をボーダーにしています
- 計算のパラメータの前提については #105 と同じです。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
