### PR TITLE
Vue Routerのルーティングをアプリ全体で使えるように修正

### DIFF
--- a/app/javascript/src/App.vue
+++ b/app/javascript/src/App.vue
@@ -1,0 +1,7 @@
+<template>
+  <router-view></router-view>
+</template>
+
+<script setup></script>
+
+<style scoped></style>

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import SimulationForm from './SimulationForm'
 import RetirementMonth from './components//simulation_form/RetirementMonth.vue'
 import EmploymentMonth from './components//simulation_form/EmploymentMonth.vue'
 import Age from './components/simulation_form/Age'
@@ -11,46 +12,20 @@ import ScheduledSocialInsurance from './components/simulation_form/ScheduledSoci
 const router = createRouter({
   history: createWebHistory(),
   routes: [
-    { path: '/simulations/new', redirect: '/simulations/new/1' },
     {
-      name: 'retirementMonth',
-      path: '/simulations/new/1',
-      component: RetirementMonth
-    },
-    {
-      name: 'employmentMonth',
-      path: '/simulations/new/2',
-      component: EmploymentMonth
-    },
-    {
-      name: 'age',
-      path: '/simulations/new/3',
-      component: Age
-    },
-    {
-      name: 'postalCode',
-      path: '/simulations/new/4',
-      component: PostalCode
-    },
-    {
-      name: 'salary',
-      path: '/simulations/new/5',
-      component: Salary
-    },
-    {
-      name: 'SocialInsurance',
-      path: '/simulations/new/6',
-      component: SocialInsurance
-    },
-    {
-      name: 'scheduledSalary',
-      path: '/simulations/new/7',
-      component: ScheduledSalary
-    },
-    {
-      name: 'scheduledSocialInsurance',
-      path: '/simulations/new/8',
-      component: ScheduledSocialInsurance
+      path: '/simulations/new',
+      component: SimulationForm,
+      redirect: '/simulations/new/1',
+      children: [
+        { path: '1', component: RetirementMonth },
+        { path: '2', component: EmploymentMonth },
+        { path: '3', component: Age },
+        { path: '4', component: PostalCode },
+        { path: '5', component: Salary },
+        { path: '6', component: SocialInsurance },
+        { path: '7', component: ScheduledSalary },
+        { path: '8', component: ScheduledSocialInsurance }
+      ]
     }
   ]
 })

--- a/app/javascript/src/simulation.js
+++ b/app/javascript/src/simulation.js
@@ -1,5 +1,5 @@
 import { createApp } from 'vue'
-import SimulationForm from './SimulationForm.vue'
+import App from './App.vue'
 import Maska from 'maska'
 import router from './router.js'
 
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const selector = '#js-simulation'
   const simulation = document.querySelector(selector)
   if (simulation) {
-    const app = createApp(SimulationForm)
+    const app = createApp(App)
     app.use(Maska)
     app.use(router)
     app.mount(selector)


### PR DESCRIPTION
FormWizardコンポーネント内だけでルーティングを行っていたが、計算結果やホーム画面もルーティングで切り替えるため、従来のルートをネストしたルートに変更し、ページそのもの自体を切り替えられ流ように変更した

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
