### PR TITLE
シミュレーション結果画面を実装

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "globals": {
         "$ref": "readonly",
         "$$": "readonly",
+        "$computed": "readonly",
         "defineProps": "readonly",
         "defineEmits": "readonly",
         "defineExpose": "readonly",

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -2,4 +2,6 @@
 
 class SimulationsController < ApplicationController
   def new; end
+
+  def show; end
 end

--- a/app/javascript/src/SimulationForm.vue
+++ b/app/javascript/src/SimulationForm.vue
@@ -7,17 +7,18 @@
 </template>
 
 <script setup>
-import { provide } from 'vue'
 import FormWizard from './components/FormWizard'
 import { useValidationSchema } from './validation-schema'
+import { useRouter } from 'vue-router'
+import { useGlobalStore } from './store/global'
 
-const simulationDate = new Date()
-provide('SIMULATION_DATE', simulationDate)
+const { simulation } = useGlobalStore()
+const params = $computed(() => simulation.params)
+const router = useRouter()
 
-const validationSchema = useValidationSchema(simulationDate)
+const validationSchema = useValidationSchema(new Date(params.simulationDate))
 
-const onSubmit = (formData) =>
-  alert(`入力結果をAPIに送信：\n${JSON.stringify(formData, null, 2)}`)
+const onSubmit = () => router.push('/simulations')
 </script>
 
 <style scope>

--- a/app/javascript/src/SimulationResult.vue
+++ b/app/javascript/src/SimulationResult.vue
@@ -1,0 +1,163 @@
+<template>
+  <div v-if="loading" class="flex justify-center my-64">
+    <div class="animate-ping h-2 w-2 bg-green-800 rounded-full"></div>
+    <div class="animate-ping h-2 w-2 bg-green-800 rounded-full mx-8"></div>
+    <div class="animate-ping h-2 w-2 bg-green-800 rounded-full"></div>
+  </div>
+  <div v-else>
+    <div class="max-w-screen-lg mx-auto pt-32 text-center">
+      <div class="mb-6 mx-32">
+        <p class="text-3xl font-bold">
+          {{ formatDate(result.retirement_month) }}に退職して、{{
+            formatDate(result.employment_month)
+          }}に就職すると...
+        </p>
+      </div>
+      <div class="mb-10 mx-42">
+        <p>
+          <span class="font-bold">約</span>
+          <span class="mx-6">
+            <span class="text-8xl text-green-700 font-bold">{{
+              formatAmount(result.grand_total)
+            }}</span>
+            <span class="text-3xl text-green-700 font-bold ml-2">円</span>
+          </span>
+          <span class="font-bold">かかります</span>
+        </p>
+      </div>
+      <div class="mb-20 mx-72 flex justify-between">
+        <div class="flex-1">
+          <p class="text-sm">国民健康保険料</p>
+          <p class="text-xl font-semi-bold">
+            {{ formatAmount(result.sub_total.insurance) }}円
+          </p>
+        </div>
+        <div class="flex-1">
+          <p class="text-sm">国民年金</p>
+          <p class="text-xl font-semi-bold">
+            {{ formatAmount(result.sub_total.pension) }}円
+          </p>
+        </div>
+        <div class="flex-1">
+          <p class="text-sm">住民税</p>
+          <p class="text-xl font-semi-bold">
+            {{ formatAmount(result.sub_total.residence) }}円
+          </p>
+        </div>
+      </div>
+      <div class="flex flex-wrap justify-around mb-52 mx-64">
+        <button
+          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg font-bold bg-green-700 text-white hover:bg-green-800 shadow-xl"
+          @click="moveForm"
+        >
+          もういちど計算する
+        </button>
+        <button
+          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg font-bold bg-amber-400 text-white hover:bg-amber-500 shadow-xl"
+          @click="scrollDetail"
+        >
+          詳細をみる
+        </button>
+      </div>
+    </div>
+    <div class="bg-gray-200 py-28" id="detail">
+      <div
+        class="max-w-screen-lg mx-auto px-12 py-16 bg-white rounded-3xl mb-16"
+      >
+        <h2 class="text-center font-bold text-4xl mb-6">個人負担額の詳細</h2>
+        <div
+          v-for="monthly_payment in result.monthly_payment"
+          :key="monthly_payment.month"
+          class="px-6 mb-8"
+        >
+          <div class="separator">
+            <p class="font-bold text-2xl">
+              {{ formatDate(monthly_payment.month) }}
+            </p>
+          </div>
+          <div class="px-8 pt-4">
+            <ul>
+              <li
+                class="type-icon before:content-['保'] text-lg font-semi-bold mb-4"
+              >
+                当月分：{{ formatAmount(monthly_payment.fee.insurance) }}円
+              </li>
+              <li
+                class="type-icon before:content-['年'] text-lg font-semi-bold mb-4"
+              >
+                当月分：{{ formatAmount(monthly_payment.fee.pension) }}円
+              </li>
+              <li
+                class="type-icon before:content-['税'] text-lg font-semi-bold mb-4"
+              >
+                当月分：{{ formatAmount(monthly_payment.fee.residence) }}円
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="flex justify-center">
+        <button
+          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg font-bold bg-green-100 text-gray-500 hover:bg-green-200 shadow-xl"
+          @click="scrollTop"
+        >
+          ページ上部へ
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { format } from 'date-fns'
+import { useRouter } from 'vue-router'
+import { useGlobalStore } from './store/global'
+
+const router = useRouter()
+const { simulation, step } = useGlobalStore()
+
+simulation.load_result()
+
+const result = $computed(() => simulation.result)
+const loading = $computed(() => simulation.loading)
+
+const formatDate = (dateString) => {
+  return format(new Date(dateString), 'yyyy年MM月')
+}
+
+const formatAmount = (amount) => {
+  return new Intl.NumberFormat('ja').format(amount)
+}
+
+const scrollTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth'
+  })
+}
+
+const scrollDetail = () => {
+  const element = document.getElementById('detail')
+  element.scrollIntoView({
+    behavior: 'smooth',
+    block: 'start'
+  })
+}
+
+const moveForm = () => {
+  router.push('/simulations/new')
+  step.reset()
+  simulation.reset_params()
+  simulation.reset_result()
+}
+</script>
+
+<style scoped>
+.separator {
+  @apply flex items-center after:content-[''] after:border-t-2 after:border-gray-200 after:border-solid after:flex-1 after:ml-2;
+}
+
+.type-icon {
+  @apply relative before:left-0 before:top-1/2 before:-translate-y-2/4 pl-10 before:inline-block before:bg-green-700 before:text-white before:font-bold before:rounded-full before:text-base before:h-8 before:w-8 before:leading-8 before:absolute before:text-center;
+}
+</style>

--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -2,15 +2,13 @@
   <form class="mt-24" @submit="onSubmit">
     <div class="flex">
       <h2>
-        <span class="text-6xl font-bold text-green-700">{{
-          zeroPadCurrentIdx
-        }}</span>
+        <span class="text-6xl font-bold text-green-700">{{ displayStep }}</span>
         <span class="text-3xl font-semi-bold text-gray-400"> / </span>
         <span class="text-4xl font-bold text-green-700">{{
           zeroPadStepCounter
         }}</span>
       </h2>
-      <ProgressBar :top="currentStepIdx" :bottom="stepCounter" />
+      <ProgressBar :top="raw" :bottom="stepCounter" />
     </div>
     <div class="px-24 m-24">
       <slot />
@@ -18,7 +16,7 @@
     <div class="flex justify-between">
       <button
         class="button text-white bg-gray-300 hover:bg-gray-400 rounded-full"
-        v-if="hasPrevious"
+        v-if="step.hasPrevious"
         type="button"
         @click="goToPrev"
       >
@@ -35,13 +33,12 @@
 </template>
 
 <script setup>
-import { useForm } from 'vee-validate'
-import { computed, provide } from 'vue'
 import ProgressBar from './ProgressBar'
+import { useForm } from 'vee-validate'
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { useStorage } from '@vueuse/core'
+import { useGlobalStore } from '../store/global'
 
-const router = useRouter()
 const emit = defineEmits(['next', 'submit'])
 const props = defineProps({
   validationSchema: {
@@ -49,60 +46,39 @@ const props = defineProps({
     required: true
   }
 })
-let formData = useStorage('formData', {})
-let currentStepIdx = useStorage('currentStepIdx', 0)
-const stepCounter = 8
-provide('STEP_COUNTER', $$(stepCounter))
-provide('CURRENT_STEP_INDEX', currentStepIdx)
-provide('FORM_DATA', formData)
-const isLastStep = computed(() => currentStepIdx.value === stepCounter - 1)
-const nextStep = computed(() =>
-  isLastStep.value ? '計算結果へ' : 'つぎの質問へ'
-)
-const hasPrevious = computed(() => currentStepIdx.value > 0)
-const zeroPadCurrentIdx = computed(() =>
-  ('00' + (currentStepIdx.value + 1)).slice(-2)
-)
-const zeroPadStepCounter = computed(() => ('00' + stepCounter).slice(-2))
-const currentSchema = computed(
-  () => props.validationSchema[currentStepIdx.value]
-)
 
-// useFormでバリデーションスキーマを定義する
+const { simulation, step } = useGlobalStore()
+const router = useRouter()
+
+const raw = $computed(() => step.raw)
+const displayStep = computed(() => ('00' + step.current).slice(-2))
+
+const params = $computed(() => simulation.params)
+const stepCounter = 8
+const lastStep = $computed(() => step.raw === stepCounter - 1)
+const nextStep = computed(() => (lastStep ? '計算結果へ' : 'つぎの質問へ'))
+const zeroPadStepCounter = computed(() => ('00' + stepCounter).slice(-2))
+
 const { resetForm, handleSubmit } = useForm({
-  validationSchema: currentSchema
+  validationSchema: computed(() => props.validationSchema[raw])
 })
 
-// handleSubmitでバリデーションチェックが終わってから処理を行う。
 const onSubmit = handleSubmit((values) => {
-  formData.value = {
-    ...formData.value,
-    ...values
-  }
-  // すでに入力された値を引数として初期値設定を行うことで、
-  // 「まえの質問へ」を選択しても、値がセットされた状態になる。
-  resetForm({
-    values: {
-      ...formData.value
-    }
-  })
-  if (!isLastStep.value) {
-    currentStepIdx.value++
-    router.push(`${currentStepIdx.value + 1}`)
+  simulation.add_params(values)
+  resetForm({ values: { ...params } })
+  if (!lastStep) {
+    step.increment()
+    router.push(`${step.current}`)
     return
   }
-  emit('submit', formData.value)
+  emit('submit')
 })
 
 const goToPrev = () => {
-  if (currentStepIdx.value === 0) return
-  currentStepIdx.value--
-  resetForm({
-    values: {
-      ...formData.value
-    }
-  })
-  router.push(`${currentStepIdx.value + 1}`)
+  if (raw === 0) return
+  step.decrement()
+  resetForm({ values: { ...params } })
+  router.push(`${step.current}`)
 }
 </script>
 

--- a/app/javascript/src/components/simulation_form/Age.vue
+++ b/app/javascript/src/components/simulation_form/Age.vue
@@ -13,17 +13,18 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { computed } from 'vue'
 import { useField } from 'vee-validate'
+import { useGlobalStore } from '../../store/global'
 
-const formData = inject('FORM_DATA')
+const { simulation } = useGlobalStore()
+const params = $computed(() => simulation.params)
+
 const ageValue = computed({
-  get: () => age.value || formData.value.age,
-  set: (value) => {
-    age.value = value
-  }
+  get: () => age.value || params.age,
+  set: (value) => (age.value = value)
 })
 let { value: age, errorMessage: error, handleChange } = useField('age')
-const setDefaultValue = () => (age.value = formData.value.age)
+const setDefaultValue = () => (age.value = params.age)
 setDefaultValue()
 </script>

--- a/app/javascript/src/components/simulation_form/EmploymentMonth.vue
+++ b/app/javascript/src/components/simulation_form/EmploymentMonth.vue
@@ -18,22 +18,23 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
-import { getYear, subMonths, addYears, format } from 'date-fns'
+import { addYears, format } from 'date-fns'
+import { useGlobalStore } from '../../store/global'
 
-const base = inject('SIMULATION_DATE')
+const { simulation } = useGlobalStore()
+const params = $computed(() => simulation.params)
+
+const base = new Date(params.simulationDate)
 const from = format(base, 'yyyy/MM')
 const to = format(
   new Date(getYear(addYears(subMonths(base, 3), 2)), 3, 1),
   'yyyy/MM'
 )
-const formData = inject('FORM_DATA')
 const employmentMonthValue = computed({
-  get: () => employmentMonth.value || formData.value.employmentMonth,
-  set: (value) => {
-    employmentMonth.value = value
-  }
+  get: () => employmentMonth.value || params.employmentMonth,
+  set: (value) => (employmentMonth.value = value)
 })
 let { value: retirementMonth } = useField('retirementMonth')
 let {
@@ -42,9 +43,8 @@ let {
   handleChange
 } = useField('employmentMonth')
 
-const setDefaultValue = () => {
-  retirementMonth.value = formData.value.retirementMonth
-  employmentMonth.value = formData.value.employmentMonth
-}
-setDefaultValue()
+onMounted(() => {
+  retirementMonth.value = params.retirementMonth
+  employmentMonth.value = params.employmentMonth
+})
 </script>

--- a/app/javascript/src/components/simulation_form/EmploymentMonth.vue
+++ b/app/javascript/src/components/simulation_form/EmploymentMonth.vue
@@ -20,18 +20,18 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
-import { addYears, format } from 'date-fns'
+import { addMonths, addYears, format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
+import { useFinancialYear } from '../../composables/use-financial-year'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
 
 const base = new Date(params.simulationDate)
+const { endOfYear } = useFinancialYear(addYears(base, 1), 4)
 const from = format(base, 'yyyy/MM')
-const to = format(
-  new Date(getYear(addYears(subMonths(base, 3), 2)), 3, 1),
-  'yyyy/MM'
-)
+const to = format(addMonths(endOfYear, 1), 'yyyy/MM')
+
 const employmentMonthValue = computed({
   get: () => employmentMonth.value || params.employmentMonth,
   set: (value) => (employmentMonth.value = value)

--- a/app/javascript/src/components/simulation_form/PostalCode.vue
+++ b/app/javascript/src/components/simulation_form/PostalCode.vue
@@ -19,19 +19,22 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import axios from 'axios'
 import axiosJsonpAdapter from 'axios-jsonp'
+import { useGlobalStore } from '../../store/global'
+
+const { simulation } = useGlobalStore()
+const params = $computed(() => simulation.params)
 
 let { value: postalCode, errorMessage: error } = useField('postalCode')
-const formData = inject('FORM_DATA')
+
 const postalCodeValue = computed({
-  get: () => postalCode.value || formData.value.postalCode,
-  set: (value) => {
-    postalCode.value = value
-  }
+  get: () => postalCode.value || params.postalCode,
+  set: (value) => (postalCode.value = value)
 })
+
 const result = computed(() => {
   if (!postalCode.value) return `該当する市区町村がありません`
   const zipCode = postalCode.value.replace(/[^\d]+/g, '')
@@ -41,8 +44,10 @@ const result = computed(() => {
     return `該当する市区町村がありません`
   }
 })
+
 let prefecture = $ref('')
 let city = $ref('')
+
 const searchAddress = async () => {
   const zipCode = postalCode.value.replace(/[^\d]+/g, '')
   if (!/^\d{7}$/.test(zipCode)) return
@@ -53,6 +58,6 @@ const searchAddress = async () => {
   prefecture = response.data.pref
   city = response.data.city
 }
-const setDefaultValue = () => (postalCode.value = formData.value.postalCode)
-setDefaultValue()
+
+onMounted(() => (postalCode.value = params.postalCode))
 </script>

--- a/app/javascript/src/components/simulation_form/RetirementMonth.vue
+++ b/app/javascript/src/components/simulation_form/RetirementMonth.vue
@@ -18,23 +18,25 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { getYear, subMonths, addYears, format } from 'date-fns'
+import { useGlobalStore } from '../../store/global'
 
-const formData = inject('FORM_DATA')
-const retirementMonthValue = computed({
-  get: () => retirementMonth.value || formData.value.retirementMonth,
-  set: (value) => {
-    retirementMonth.value = value || formData.value.retirementMonth
-  }
-})
-const base = inject('SIMULATION_DATE')
+const { simulation } = useGlobalStore()
+const params = $computed(() => simulation.params)
+
+const base = new Date(params.simulationDate)
 const from = format(base, 'yyyy/MM')
 const to = format(
   new Date(getYear(addYears(subMonths(base, 3), 2)), 3, 1),
   'yyyy/MM'
 )
+
+const retirementMonthValue = computed({
+  get: () => retirementMonth.value || params.retirementMonth,
+  set: (value) => (retirementMonth.value = value)
+})
 
 let {
   value: retirementMonth,
@@ -42,7 +44,5 @@ let {
   handleChange
 } = useField('retirementMonth')
 
-const setDefaultValue = () =>
-  (retirementMonth.value = formData.value.retirementMonth)
-setDefaultValue()
+onMounted(() => (retirementMonth.value = params.retirementMonth))
 </script>

--- a/app/javascript/src/components/simulation_form/RetirementMonth.vue
+++ b/app/javascript/src/components/simulation_form/RetirementMonth.vue
@@ -20,18 +20,17 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
-import { getYear, subMonths, addYears, format } from 'date-fns'
+import { addMonths, addYears, format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
+import { useFinancialYear } from '../../composables/use-financial-year'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
 
 const base = new Date(params.simulationDate)
+const { endOfYear } = useFinancialYear(addYears(base, 1), 4)
 const from = format(base, 'yyyy/MM')
-const to = format(
-  new Date(getYear(addYears(subMonths(base, 3), 2)), 3, 1),
-  'yyyy/MM'
-)
+const to = format(addMonths(endOfYear, 1), 'yyyy/MM')
 
 const retirementMonthValue = computed({
   get: () => retirementMonth.value || params.retirementMonth,

--- a/app/javascript/src/components/simulation_form/Salary.vue
+++ b/app/javascript/src/components/simulation_form/Salary.vue
@@ -21,22 +21,25 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { getYear, subMonths, subYears, format } from 'date-fns'
+import { useGlobalStore } from '../../store/global'
 
-const formData = inject('FORM_DATA')
+const { simulation } = useGlobalStore()
+const params = $computed(() => simulation.params)
+
 const salaryValue = computed({
-  get: () => salary.value || formData.value.salary,
-  set: (value) => {
-    salary.value = value
-  }
+  get: () => salary.value || params.salary,
+  set: (value) => (salary.value = value)
 })
-const base = inject('SIMULATION_DATE')
+
+const base = new Date(params.simulationDate)
 const lastYear = getYear(subYears(subMonths(base, 3), 1))
 const from = format(new Date(lastYear, 0, 1), 'yyyy年M月d日')
 const to = format(new Date(lastYear, 11, 31), 'yyyy年M月d日')
+
 let { value: salary, errorMessage: error, handleChange } = useField('salary')
-const setDefaultValue = () => (salary.value = formData.value.salary)
-setDefaultValue()
+
+onMounted(() => (salary.value = params.salary))
 </script>

--- a/app/javascript/src/components/simulation_form/Salary.vue
+++ b/app/javascript/src/components/simulation_form/Salary.vue
@@ -23,8 +23,9 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
-import { getYear, subMonths, subYears, format } from 'date-fns'
+import { format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
+import { useFinancialYear } from '../../composables/use-financial-year'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
@@ -35,10 +36,9 @@ const salaryValue = computed({
 })
 
 const base = new Date(params.simulationDate)
-const lastYear = getYear(subYears(subMonths(base, 3), 1))
-const from = format(new Date(lastYear, 0, 1), 'yyyy年M月d日')
-const to = format(new Date(lastYear, 11, 31), 'yyyy年M月d日')
-
+const { lastBeginningOfYear, lastEndOfYear } = useFinancialYear(base, 1, 4)
+const from = format(lastBeginningOfYear, 'yyyy年M月d日')
+const to = format(lastEndOfYear, 'yyyy年M月d日')
 let { value: salary, errorMessage: error, handleChange } = useField('salary')
 
 onMounted(() => (salary.value = params.salary))

--- a/app/javascript/src/components/simulation_form/ScheduledSalary.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSalary.vue
@@ -21,27 +21,29 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { getYear, subMonths, format } from 'date-fns'
+import { useGlobalStore } from '../../store/global'
 
-const formData = inject('FORM_DATA')
-const scheduledSalaryValue = computed({
-  get: () => scheduledSalary.value || formData.value.scheduledSalary,
-  set: (value) => {
-    scheduledSalary.value = value
-  }
-})
-const base = inject('SIMULATION_DATE')
+const { simulation } = useGlobalStore()
+const params = $computed(() => simulation.params)
+
+const base = new Date(params.simulationDate)
 const thisYear = getYear(subMonths(base, 3))
 const from = format(new Date(thisYear, 0, 1), 'yyyy年M月d日')
 const to = format(new Date(thisYear, 11, 31), 'yyyy年M月d日')
+
+const scheduledSalaryValue = computed({
+  get: () => scheduledSalary.value || params.scheduledSalary,
+  set: (value) => (scheduledSalary.value = value)
+})
+
 let {
   value: scheduledSalary,
   errorMessage: error,
   handleChange
 } = useField('scheduledSalary')
-const setDefaultValue = () =>
-  (scheduledSalary.value = formData.value.scheduledSalary)
-setDefaultValue()
+
+onMounted(() => (scheduledSalary.value = params.scheduledSalary))
 </script>

--- a/app/javascript/src/components/simulation_form/ScheduledSalary.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSalary.vue
@@ -23,22 +23,22 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
-import { getYear, subMonths, format } from 'date-fns'
+import { format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
+import { useFinancialYear } from '../../composables/use-financial-year'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
-
-const base = new Date(params.simulationDate)
-const thisYear = getYear(subMonths(base, 3))
-const from = format(new Date(thisYear, 0, 1), 'yyyy年M月d日')
-const to = format(new Date(thisYear, 11, 31), 'yyyy年M月d日')
 
 const scheduledSalaryValue = computed({
   get: () => scheduledSalary.value || params.scheduledSalary,
   set: (value) => (scheduledSalary.value = value)
 })
 
+const base = new Date(params.simulationDate)
+const { beginningOfYear, endOfYear } = useFinancialYear(base, 1, 4)
+const from = format(beginningOfYear, 'yyyy年M月d日')
+const to = format(endOfYear, 'yyyy年M月d日')
 let {
   value: scheduledSalary,
   errorMessage: error,

--- a/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
@@ -36,16 +36,16 @@
 import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { useGlobalStore } from '../../store/global'
-import { getYear, subMonths, format } from 'date-fns'
+import { useFinancialYear } from '../../composables/use-financial-year'
+import { format } from 'date-fns'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
 
 const base = new Date(params.simulationDate)
-const thisYear = getYear(subMonths(base, 3))
-const from = format(new Date(thisYear, 0, 1), 'yyyy年M月d日')
-const to = format(new Date(thisYear, 11, 31), 'yyyy年M月d日')
-const formData = inject('FORM_DATA')
+const { beginningOfYear, endOfYear } = useFinancialYear(base, 1, 4)
+const from = format(beginningOfYear, 'yyyy年M月d日')
+const to = format(endOfYear, 'yyyy年M月d日')
 
 const scheduledSocialInsuranceValue = computed({
   get: () => scheduledSocialInsurance.value || params.scheduledSocialInsurance,

--- a/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
@@ -33,28 +33,32 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
+import { useGlobalStore } from '../../store/global'
 import { getYear, subMonths, format } from 'date-fns'
 
-const base = inject('SIMULATION_DATE')
+const { simulation } = useGlobalStore()
+const params = $computed(() => simulation.params)
+
+const base = new Date(params.simulationDate)
 const thisYear = getYear(subMonths(base, 3))
 const from = format(new Date(thisYear, 0, 1), 'yyyy年M月d日')
 const to = format(new Date(thisYear, 11, 31), 'yyyy年M月d日')
 const formData = inject('FORM_DATA')
+
 const scheduledSocialInsuranceValue = computed({
-  get: () =>
-    scheduledSocialInsurance.value || formData.value.scheduledSocialInsurance,
-  set: (value) => {
-    scheduledSocialInsurance.value = value
-  }
+  get: () => scheduledSocialInsurance.value || params.scheduledSocialInsurance,
+  set: (value) => (scheduledSocialInsurance.value = value)
 })
+
 let {
   value: scheduledSocialInsurance,
   errorMessage: error,
   handleChange
 } = useField('scheduledSocialInsurance')
-const setDefaultValue = () =>
-  (scheduledSocialInsurance.value = formData.value.scheduledSocialInsurance)
-setDefaultValue()
+
+onMounted(
+  () => (scheduledSocialInsurance.value = params.scheduledSocialInsurance)
+)
 </script>

--- a/app/javascript/src/components/simulation_form/SocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/SocialInsurance.vue
@@ -23,17 +23,18 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
-import { getYear, subMonths, subYears, format } from 'date-fns'
+import { format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
+import { useFinancialYear } from '../../composables/use-financial-year'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
 
 const base = new Date(params.simulationDate)
-const lastYear = getYear(subYears(subMonths(base, 3), 1))
-const from = format(new Date(lastYear, 0, 1), 'yyyy年M月d日')
-const to = format(new Date(lastYear, 11, 31), 'yyyy年M月d日')
-const formData = inject('FORM_DATA')
+const { lastBeginningOfYear, lastEndOfYear } = useFinancialYear(base, 1, 4)
+const from = format(lastBeginningOfYear, 'yyyy年M月d日')
+const to = format(lastEndOfYear, 'yyyy年M月d日')
+
 const socialInsuranceValue = computed({
   get: () => socialInsurance.value || params.socialInsurance,
   set: (value) => (socialInsurance.value = value)

--- a/app/javascript/src/components/simulation_form/SocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/SocialInsurance.vue
@@ -21,27 +21,29 @@
 </template>
 
 <script setup>
-import { inject, computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { getYear, subMonths, subYears, format } from 'date-fns'
+import { useGlobalStore } from '../../store/global'
 
-const base = inject('SIMULATION_DATE')
+const { simulation } = useGlobalStore()
+const params = $computed(() => simulation.params)
+
+const base = new Date(params.simulationDate)
 const lastYear = getYear(subYears(subMonths(base, 3), 1))
 const from = format(new Date(lastYear, 0, 1), 'yyyy年M月d日')
 const to = format(new Date(lastYear, 11, 31), 'yyyy年M月d日')
 const formData = inject('FORM_DATA')
 const socialInsuranceValue = computed({
-  get: () => socialInsurance.value || formData.value.socialInsurance,
-  set: (value) => {
-    socialInsurance.value = value
-  }
+  get: () => socialInsurance.value || params.socialInsurance,
+  set: (value) => (socialInsurance.value = value)
 })
+
 let {
   value: socialInsurance,
   errorMessage: error,
   handleChange
 } = useField('socialInsurance')
-const setDefaultValue = () =>
-  (socialInsurance.value = formData.value.socialInsurance)
-setDefaultValue()
+
+onMounted(() => (socialInsurance.value = params.socialInsurance))
 </script>

--- a/app/javascript/src/composables/use-financial-year.js
+++ b/app/javascript/src/composables/use-financial-year.js
@@ -1,0 +1,24 @@
+import { addMonths, subMonths, subYears, lastDayOfMonth } from 'date-fns'
+
+export const useFinancialYear = (
+  date,
+  beginning_of_fiscal_year = 1,
+  date_beginning_of_fiscal_year = beginning_of_fiscal_year
+) => {
+  const year =
+    date_beginning_of_fiscal_year === 1
+      ? date.getFullYear()
+      : subMonths(date, date_beginning_of_fiscal_year).getFullYear()
+  const beginningOfYear = new Date(year, beginning_of_fiscal_year - 1, 1)
+  const lastBeginningOfYear = subYears(beginningOfYear, 1)
+  const endOfYear = lastDayOfMonth(addMonths(beginningOfYear, 11))
+  const lastEndOfYear = subYears(endOfYear, 1)
+
+  return {
+    beginningOfYear: beginningOfYear,
+    lastBeginningOfYear,
+    endOfYear: endOfYear,
+    lastEndOfYear,
+    year
+  }
+}

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import SimulationForm from './SimulationForm'
+import SimulationResult from './SimulationResult'
 import RetirementMonth from './components//simulation_form/RetirementMonth.vue'
 import EmploymentMonth from './components//simulation_form/EmploymentMonth.vue'
 import Age from './components/simulation_form/Age'
@@ -26,7 +27,8 @@ const router = createRouter({
         { path: '7', component: ScheduledSalary },
         { path: '8', component: ScheduledSocialInsurance }
       ]
-    }
+    },
+    { path: '/simulations', component: SimulationResult }
   ]
 })
 

--- a/app/javascript/src/simulation.js
+++ b/app/javascript/src/simulation.js
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import Maska from 'maska'
 import router from './router.js'
+import globalStore, { GlobalStoreKey } from './store/global'
 
 document.addEventListener('DOMContentLoaded', () => {
   const selector = '#js-simulation'
@@ -10,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const app = createApp(App)
     app.use(Maska)
     app.use(router)
+    app.provide(GlobalStoreKey, globalStore())
     app.mount(selector)
   }
 })

--- a/app/javascript/src/store/global.js
+++ b/app/javascript/src/store/global.js
@@ -1,0 +1,20 @@
+import { inject } from 'vue'
+import simulationStore from './simulation'
+import stepStore from './step'
+
+export default function globalStore() {
+  return {
+    simulation: simulationStore(),
+    step: stepStore()
+  }
+}
+
+export const GlobalStoreKey = 'GlobalStore'
+
+export function useGlobalStore() {
+  const store = inject(GlobalStoreKey)
+  if (!store) {
+    throw new Error(`${GlobalStoreKey} is not provided`)
+  }
+  return store
+}

--- a/app/javascript/src/store/simulation.js
+++ b/app/javascript/src/store/simulation.js
@@ -1,0 +1,96 @@
+import { useStorage } from '@vueuse/core'
+import axios from 'axios'
+import axiosJsonpAdapter from 'axios-jsonp'
+import { format } from 'date-fns'
+
+export default function simulationStore() {
+  const state = useStorage(
+    'State',
+    {
+      params: {
+        simulationDate: new Date()
+      },
+      loading: false,
+      result: {}
+    },
+    sessionStorage
+  )
+
+  const searchAddress = async (params) => {
+    const zipCode = params.postalCode.replace(/[^\d]+/g, '')
+    if (!/^\d{7}$/.test(zipCode)) return
+    const response = await axios.get(
+      `https://api.zipaddress.net/?zipcode=${zipCode}`,
+      { adapter: axiosJsonpAdapter }
+    )
+
+    return response.data
+  }
+
+  const formatDate = (date) => format(date, 'yyyy-MM-dd')
+
+  const getResult = async () => {
+    const params = state.value.params
+    const address = await searchAddress(params)
+    const parameter = new URLSearchParams({
+      simulation_date: formatDate(new Date(params.simulationDate)),
+      retirement_month: formatDate(new Date(`${params.retirementMonth}/1`)),
+      employment_month: formatDate(new Date(`${params.employmentMonth}/1`)),
+      age: params.age,
+      prefecture: address.pref,
+      city: address.city,
+      salary: params.salary,
+      scheduled_salary: params.scheduled_salary,
+      social_insurance: params.social_insurance,
+      scheduled_social_insurance: params.scheduled_social_insurance
+    }).toString()
+
+    const simulationApi = `/api/simulations?${parameter}`
+    const response = await fetch(simulationApi, {
+      method: 'GET',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+      redirect: 'manual'
+    })
+    const json = await response.json()
+    return json.simulation
+  }
+
+  return {
+    get params() {
+      return state.value.params
+    },
+
+    get result() {
+      return state.value.result
+    },
+
+    get loading() {
+      return state.value.loading
+    },
+
+    add_params(values) {
+      state.value.params = {
+        ...state.value.params,
+        ...values
+      }
+    },
+
+    reset_params() {
+      state.value.params = { simulationDate: new Date() }
+    },
+
+    async load_result() {
+      state.value.loading = true
+      try {
+        state.value.result = await getResult()
+      } finally {
+        state.value.loading = false
+      }
+    },
+
+    reset_result() {
+      state.value.result = {}
+    }
+  }
+}

--- a/app/javascript/src/store/step.js
+++ b/app/javascript/src/store/step.js
@@ -1,0 +1,32 @@
+import { useStorage } from '@vueuse/core'
+import { computed } from 'vue'
+
+export default function stepStore() {
+  const state = useStorage('Step', 0, sessionStorage)
+
+  return {
+    get raw() {
+      return state.value
+    },
+
+    get current() {
+      return computed(() => state.value + 1).value
+    },
+
+    get hasPrevious() {
+      return computed(() => state.value > 0).value
+    },
+
+    increment() {
+      state.value++
+    },
+
+    decrement() {
+      state.value--
+    },
+
+    reset() {
+      state.value = 0
+    }
+  }
+}

--- a/app/javascript/src/validation-schema.js
+++ b/app/javascript/src/validation-schema.js
@@ -27,15 +27,15 @@ export const useValidationSchema = (baseDate) => {
       retirementMonth: yup.date(),
       employmentMonth: yup
         .date()
-        .required('就職予定月は必須です')
+        .required('転職予定月は必須です')
         .typeError('無効な日付です。YYYY/MMの形式で入力してください。')
         .min(
           yup.ref('retirementMonth'),
-          `就職予定月には、退職月以降の月を指定してください`
+          `転職予定月には、退職月以降の月を指定してください`
         )
         .max(
           computableTo,
-          `就職予定月には ${computableTo} 以前の月を指定してください`
+          `転職予定月には ${computableTo} 以前の月を指定してください`
         )
     }),
     yup.object({

--- a/app/views/simulations/show.html.slim
+++ b/app/views/simulations/show.html.slim
@@ -1,0 +1,1 @@
+#js-simulation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resource :simulations, only: %i(new)
+  resource :simulations, only: %i(new show)
   resources :insurances, only: %i(index new create edit update)
   resources :pensions, only: %i(index new create edit update)
   get 'simulations/new/*path', to: 'simulations#new'


### PR DESCRIPTION
Closes #114

## やったこと

- シミュレーション結果画面を実装
- シミュレーションのパラメータ等を保持するストアを作成
    - 状態管理について、Vuexではなく自前のストアを導入した理由は次のとおりです。
          - PR作成時点でVuexがCompositionAPIに対して、OptionsAPIに提供していた全ての機能を提供できていないこと
          - アプリの状態がそこまで複雑でないこと
          - Vue3系のエコシステムとの連携の観点から、自前のストアを立てた方が場当たり的な余計なコードを書かなくてよいこと

## UI

![CleanShot 2022-03-02 at 20 46 33](https://user-images.githubusercontent.com/61409641/156356102-dcd806e2-9549-4ea3-a7a0-3386c0b433c2.gif)

## 申し送り事項

- フロントエンド側はSPAとなっており、RailsのE2Eでテストすると大変なので、Cypressを導入予定です（現時点で未導入）
- 実装に際して、`computed`へのReactivity Transformを使用したため、Lintのスタイルに追加しています。
    - 本来であれば別PRかと思いますが、規模が小さいのでこのPRに含めています。

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
