### PR TITLE
国民健康保険料登録「市区町村名」に都道府県名も表示するように変更

### DIFF
--- a/app/views/insurances/_form.html.slim
+++ b/app/views/insurances/_form.html.slim
@@ -1,5 +1,5 @@
 = render 'errors', object: insurance_form
-= form_with model: insurance_form do |f|
+= form_with model: insurance_form, html: { name: 'insurance' } do |f|
   h3.leading-7.text-lg.font-bold
     | 基本情報
   .flex.flex-col.mb-4

--- a/app/views/insurances/_form.html.slim
+++ b/app/views/insurances/_form.html.slim
@@ -8,7 +8,7 @@
   .flex.flex-col.mb-4
     = f.label :local_gov_code, class: 'leading-7 text-sm font-semi-bold'
     .w-full.rounded-md.border-2.border-gray-200.focus:ring-1.focus:ring-green-300.text-base.outline-none.text-gray-900.py-1.px-3.leading-8.transition-colors.duration-200.ease-in-out
-      = f.collection_select :local_gov_code, JpLocalGov.all, :code, :city, include_blank: true
+      = f.collection_select :local_gov_code, JpLocalGov.all, :code, ->(lg) { "#{lg.prefecture} #{lg.city}" }, include_blank: true
     h3.leading-7.text-lg.font-bold.mt-8
       | 医療分
     .flex.flex-col.mb-4

--- a/app/views/pensions/_form.html.slim
+++ b/app/views/pensions/_form.html.slim
@@ -1,5 +1,5 @@
 = render 'errors', object: pension
-= form_with model: pension do |f|
+= form_with model: pension, html: { name: 'pension' } do |f|
   .flex.flex-col.mb-4
     = f.label :year, class: 'leading-7 text-sm font-semi-bold'
     = f.number_field :year, class: 'w-full rounded-md border-2 border-gray-200 focus:border-green-700 text-base outline-none text-gray-900 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out'

--- a/spec/system/insurance_spec.rb
+++ b/spec/system/insurance_spec.rb
@@ -19,35 +19,37 @@ RSpec.describe 'Insurance', type: :system, js: true do
 
       expect(page).to have_content '国民健康保険料登録'
 
-      fill_in '年度', with: insurance_form.year
-      select "#{JpLocalGov.find(insurance_form.local_gov_code).prefecture} #{JpLocalGov.find(insurance_form.local_gov_code).city}", from: '市区町村名'
-      fill_in '所得割（医療分）', with: insurance_form.medical_income_basis
-      fill_in '資産割（医療分）', with: insurance_form.medical_asset_basis
-      fill_in '均等割（医療分）', with: insurance_form.medical_capita_basis
-      fill_in '平等割（医療分）', with: insurance_form.medical_household_basis
-      fill_in '限度額（医療分）', with: insurance_form.medical_limit
-      fill_in '所得割（後期高齢者支援分）', with: insurance_form.elderly_income_basis
-      fill_in '資産割（後期高齢者支援分）', with: insurance_form.elderly_asset_basis
-      fill_in '均等割（後期高齢者支援分）', with: insurance_form.elderly_capita_basis
-      fill_in '平等割（後期高齢者支援分）', with: insurance_form.elderly_household_basis
-      fill_in '限度額（後期高齢者支援分）', with: insurance_form.elderly_limit
-      fill_in '所得割（介護分）', with: insurance_form.care_income_basis
-      fill_in '資産割（介護分）', with: insurance_form.care_asset_basis
-      fill_in '均等割（介護分）', with: insurance_form.care_capita_basis
-      fill_in '平等割（介護分）', with: insurance_form.care_household_basis
-      fill_in '限度額（介護分）', with: insurance_form.care_limit
-      check '1月', allow_label_click: true
-      check '2月', allow_label_click: true
-      check '3月', allow_label_click: true
-      check '4月', allow_label_click: true
-      check '5月', allow_label_click: true
-      check '6月', allow_label_click: true
-      check '7月', allow_label_click: true
-      check '8月', allow_label_click: true
-      check '9月', allow_label_click: true
-      check '10月', allow_label_click: true
-      check '11月', allow_label_click: true
-      check '12月', allow_label_click: true
+      within 'form[name=insurance]' do
+        fill_in '年度', with: insurance_form.year
+        select "#{JpLocalGov.find(insurance_form.local_gov_code).prefecture} #{JpLocalGov.find(insurance_form.local_gov_code).city}", from: '市区町村名'
+        fill_in '所得割（医療分）', with: insurance_form.medical_income_basis
+        fill_in '資産割（医療分）', with: insurance_form.medical_asset_basis
+        fill_in '均等割（医療分）', with: insurance_form.medical_capita_basis
+        fill_in '平等割（医療分）', with: insurance_form.medical_household_basis
+        fill_in '限度額（医療分）', with: insurance_form.medical_limit
+        fill_in '所得割（後期高齢者支援分）', with: insurance_form.elderly_income_basis
+        fill_in '資産割（後期高齢者支援分）', with: insurance_form.elderly_asset_basis
+        fill_in '均等割（後期高齢者支援分）', with: insurance_form.elderly_capita_basis
+        fill_in '平等割（後期高齢者支援分）', with: insurance_form.elderly_household_basis
+        fill_in '限度額（後期高齢者支援分）', with: insurance_form.elderly_limit
+        fill_in '所得割（介護分）', with: insurance_form.care_income_basis
+        fill_in '資産割（介護分）', with: insurance_form.care_asset_basis
+        fill_in '均等割（介護分）', with: insurance_form.care_capita_basis
+        fill_in '平等割（介護分）', with: insurance_form.care_household_basis
+        fill_in '限度額（介護分）', with: insurance_form.care_limit
+        check '1月', allow_label_click: true
+        check '2月', allow_label_click: true
+        check '3月', allow_label_click: true
+        check '4月', allow_label_click: true
+        check '5月', allow_label_click: true
+        check '6月', allow_label_click: true
+        check '7月', allow_label_click: true
+        check '8月', allow_label_click: true
+        check '9月', allow_label_click: true
+        check '10月', allow_label_click: true
+        check '11月', allow_label_click: true
+        check '12月', allow_label_click: true
+      end
 
       expect { click_button '登録' }
         .to change { Insurance.count }.from(0).to(1)

--- a/spec/system/insurance_spec.rb
+++ b/spec/system/insurance_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Insurance', type: :system, js: true do
       expect(page).to have_content '国民健康保険料登録'
 
       fill_in '年度', with: insurance_form.year
-      select JpLocalGov.find(insurance_form.local_gov_code).city, from: '市区町村名'
+      select "#{JpLocalGov.find(insurance_form.local_gov_code).prefecture} #{JpLocalGov.find(insurance_form.local_gov_code).city}", from: '市区町村名'
       fill_in '所得割（医療分）', with: insurance_form.medical_income_basis
       fill_in '資産割（医療分）', with: insurance_form.medical_asset_basis
       fill_in '均等割（医療分）', with: insurance_form.medical_capita_basis

--- a/spec/system/pension_spec.rb
+++ b/spec/system/pension_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe 'Pension', type: :system, js: true do
 
       expect(page).to have_content '国民年金保険料登録'
 
-      fill_in '年度', with: pension.year
-      fill_in '保険料', with: pension.contribution
+      within 'form[name=pension]' do
+        fill_in '年度', with: pension.year
+        fill_in '保険料', with: pension.contribution
+      end
 
       expect { click_button '登録' }.to change { Pension.count }.from(0).to(1)
       assert_current_path pensions_path


### PR DESCRIPTION
Closes #123 

## バグの原因

### やっていたこと
変更前のテストでは、Factoryからランダムに選ばれた地方公共団体コードを用いて、「国民健康保険料登録」画面の「市区町村」セレクトボックスの市区町村名を選択していた。

### バグの原因
日本には「同じ名前の市区町村」が複数存在する。それに該当する市区町村のコードが選択された場合、Capybara側で選択対象を絞りきれずエラーになっていた。

## 対応

### 方針

そもそも画面から登録する場合にも「同じ名前の市区町村」を判別する手段がなかったため、「都道府県名」をセレクトボックスに表示するように変更し、テストもそれにあわせる形で修正しました。

### UI

![CleanShot 2022-03-03 at 09 30 02](https://user-images.githubusercontent.com/61409641/156473147-2adca265-7dfb-4a52-9e43-5a33b5663983.png)

## 申し送り事項

テスト修正に際し、複数入力を`fill_in`単体で行なっていたので、`within`でまとめました。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
