### PR TITLE
APIへのストア値の受け渡しのtypoを修正

### DIFF
--- a/app/javascript/src/store/simulation.js
+++ b/app/javascript/src/store/simulation.js
@@ -40,9 +40,9 @@ export default function simulationStore() {
       prefecture: address.pref,
       city: address.city,
       salary: params.salary,
-      scheduled_salary: params.scheduled_salary,
-      social_insurance: params.social_insurance,
-      scheduled_social_insurance: params.scheduled_social_insurance
+      scheduled_salary: params.scheduledSalary,
+      social_insurance: params.socialInsurance,
+      scheduled_social_insurance: params.scheduledSocialInsurance
     }).toString()
 
     const simulationApi = `/api/simulations?${parameter}`


### PR DESCRIPTION
JS側ではキャメルケースで定義している値をスネークケースで指定していたため修正した


---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
