### PR TITLE
パラメータの処理をParamParserクラスに一任

### DIFF
--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -6,19 +6,8 @@ class Simulation
 
   CATEGORY = %i[insurance pension residence].freeze
 
-  attr_reader :retirement_month, :employment_month
-
   def initialize(params)
-    @retirement_month = Time.zone.parse(params[:retirement_month])
-    @employment_month = Time.zone.parse(params[:employment_month])
-    @prefecture = params[:prefecture]
-    @city = params[:city]
-    @age = params[:age].to_i
-    @simulation_date = Time.zone.parse(params[:simulation_date])
-    @salary = params[:salary].to_i
-    @scheduled_salary = params[:scheduled_salary].to_i
-    @social_insurance = params[:social_insurance].to_i
-    @scheduled_social_insurance = params[:scheduled_social_insurance].to_i
+    @param_parser = ParamParser.new(params)
   end
 
   def grand_total
@@ -36,23 +25,27 @@ class Simulation
     end
   end
 
+  def retirement_month
+    @param_parser.retirement_month
+  end
+
+  def employment_month
+    @param_parser.employment_month
+  end
+
   private
 
-  attr_reader :age, :simulation_date, :salary, :scheduled_salary, :social_insurance, :scheduled_social_insurance
+  attr_reader :param_parser
 
   def insurance
-    Simulation::Insurance.call(retirement_month, employment_month, local_gov_code, age, simulation_date, salary, scheduled_salary)
+    Simulation::Insurance.call(param_parser)
   end
 
   def pension
-    Simulation::Pension.call(retirement_month, employment_month)
+    Simulation::Pension.call(param_parser)
   end
 
   def residence
-    Simulation::Residence.call(retirement_month, employment_month, salary, social_insurance, scheduled_salary, scheduled_social_insurance, simulation_date)
-  end
-
-  def local_gov_code
-    JpLocalGov.where(prefecture: @prefecture, city: @city).first.code
+    Simulation::Residence.call(param_parser)
   end
 end

--- a/app/models/simulation/insurance.rb
+++ b/app/models/simulation/insurance.rb
@@ -10,9 +10,7 @@ class Simulation::Insurance
     @to = param_parser.employment_month
     @local_gov_code = param_parser.local_gov_code
     @age = param_parser.age
-    @simulation_date = param_parser.simulation_date
-    @salary = param_parser.salary
-    @scheduled_salary = param_parser.scheduled_salary
+    @salary_table = param_parser.salary_table
   end
 
   def call
@@ -21,7 +19,7 @@ class Simulation::Insurance
 
   private
 
-  attr_reader :from, :to, :local_gov_code, :age, :simulation_date, :salary, :scheduled_salary
+  attr_reader :from, :to, :local_gov_code, :age, :salary_table
 
   def monthly_insurance
     yearly_insurance.flat_map do |year, fee|
@@ -51,16 +49,6 @@ class Simulation::Insurance
       result[year] = calculate_medical(year, salary) + calculate_elderly(year, salary) + calculate_care(year, salary)
     end
     result
-  end
-
-  # NOTE: 前提：フォームで入力可能な「就職月」は`現在日付の会計年度 + 1 の 末月`まで
-  # NOTE: 計算可能な範囲を拡張する場合には、このテーブルに前提に記載の月以降の給与をセットする必要がある
-  def salary_table
-    base_fiscal_year = simulation_date.financial_year
-    {
-      base_fiscal_year => salary,
-      base_fiscal_year + 1 => scheduled_salary
-    }
   end
 
   def fiscal_years

--- a/app/models/simulation/insurance.rb
+++ b/app/models/simulation/insurance.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ParameterLists
-
 class Simulation::Insurance
-  def self.call(retirement_month, employment_month, local_gov_code, age, simulation_date, salary, scheduled_salary)
-    new(retirement_month, employment_month, local_gov_code, age, simulation_date, salary, scheduled_salary).call
+  def self.call(param_parser)
+    new(param_parser).call
   end
 
-  def initialize(retirement_month, employment_month, local_gov_code, age, simulation_date, salary, scheduled_salary)
-    @from = retirement_month
-    @to = employment_month
-    @local_gov_code = local_gov_code
-    @age = age
-    @simulation_date = simulation_date
-    @salary = salary
-    @scheduled_salary = scheduled_salary
+  def initialize(param_parser)
+    @from = param_parser.retirement_month
+    @to = param_parser.employment_month
+    @local_gov_code = param_parser.local_gov_code
+    @age = param_parser.age
+    @simulation_date = param_parser.simulation_date
+    @salary = param_parser.salary
+    @scheduled_salary = param_parser.scheduled_salary
   end
 
   def call
@@ -96,5 +94,3 @@ class Simulation::Insurance
     [fee_of_first_month, Array.new(repeat_number) { fee_of_not_first_month }].flatten
   end
 end
-
-# rubocop:enable Metrics/ParameterLists

--- a/app/models/simulation/param_parser.rb
+++ b/app/models/simulation/param_parser.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Simulation::ParamParser
+  attr_reader :retirement_month, :employment_month, :prefecture, :city, :age, :simulation_date, :salary, :scheduled_salary, :social_insurance,
+              :scheduled_social_insurance, :local_gov_code
+
+  def initialize(params)
+    @retirement_month = Time.zone.parse(params[:retirement_month])
+    @employment_month = Time.zone.parse(params[:employment_month])
+    @prefecture = params[:prefecture]
+    @city = params[:city]
+    @age = params[:age].to_i
+    @simulation_date = Time.zone.parse(params[:simulation_date])
+    @salary = params[:salary].to_i
+    @scheduled_salary = params[:scheduled_salary].to_i
+    @social_insurance = params[:social_insurance].to_i
+    @scheduled_social_insurance = params[:scheduled_social_insurance].to_i
+    @local_gov_code = build_local_gov_code
+  end
+
+  private
+
+  def build_local_gov_code
+    JpLocalGov.where(prefecture: prefecture, city: city).first.code
+  end
+end

--- a/app/models/simulation/param_parser.rb
+++ b/app/models/simulation/param_parser.rb
@@ -2,7 +2,7 @@
 
 class Simulation::ParamParser
   attr_reader :retirement_month, :employment_month, :prefecture, :city, :age, :simulation_date, :salary, :scheduled_salary, :social_insurance,
-              :scheduled_social_insurance, :local_gov_code
+              :scheduled_social_insurance, :local_gov_code, :salary_table, :social_insurance_table
 
   def initialize(params)
     @retirement_month = Time.zone.parse(params[:retirement_month])
@@ -16,11 +16,33 @@ class Simulation::ParamParser
     @social_insurance = params[:social_insurance].to_i
     @scheduled_social_insurance = params[:scheduled_social_insurance].to_i
     @local_gov_code = build_local_gov_code
+    @salary_table = build_salary_table
+    @social_insurance_table = build_social_insurance_table
   end
 
   private
 
   def build_local_gov_code
     JpLocalGov.where(prefecture: prefecture, city: city).first.code
+  end
+
+  # NOTE: 前提：フォームで入力可能な「就職月」は`現在日付の会計年度 + 1 の 末月`まで
+  # NOTE: 計算可能な範囲を拡張する場合には、このテーブルに前提に記載の月以降の給与をセットする必要がある
+  def build_salary_table
+    {
+      base_fiscal_year => salary,
+      base_fiscal_year.next => scheduled_salary
+    }
+  end
+
+  def build_social_insurance_table
+    {
+      base_fiscal_year => social_insurance,
+      base_fiscal_year.next => scheduled_social_insurance
+    }
+  end
+
+  def base_fiscal_year
+    simulation_date.financial_year
   end
 end

--- a/app/models/simulation/pension.rb
+++ b/app/models/simulation/pension.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class Simulation::Pension
-  def self.call(retirement_month, employment_month)
-    new(retirement_month, employment_month).call
+  def self.call(param_parser)
+    new(param_parser).call
   end
 
-  def initialize(retirement_month, employment_month)
-    @from = retirement_month
-    @to = employment_month
+  def initialize(param_parser)
+    @from = param_parser.retirement_month
+    @to = param_parser.employment_month
   end
 
   def call

--- a/app/models/simulation/residence.rb
+++ b/app/models/simulation/residence.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/ClassLength
-# rubocop:disable Metrics/ParameterLists
 
 class Simulation::Residence
   BASIC_DEDUCTION = 430_000
@@ -14,18 +13,18 @@ class Simulation::Residence
   DUES = [6, 8, 10, 1].freeze
   NON_TAXABLE_SALARY_LIMIT = 1_000_000
 
-  def self.call(retirement_month, employment_month, salary, social_insurance, scheduled_salary, scheduled_social_insurance, simulation_date)
-    new(retirement_month, employment_month, salary, social_insurance, scheduled_salary, scheduled_social_insurance, simulation_date).call
+  def self.call(param_parser)
+    new(param_parser).call
   end
 
-  def initialize(retirement_month, employment_month, salary, social_insurance, scheduled_salary, scheduled_social_insurance, simulation_date)
-    @from = retirement_month
-    @to = employment_month
-    @salary = salary
-    @social_insurance = social_insurance
-    @scheduled_salary = scheduled_salary
-    @scheduled_social_insurance = scheduled_social_insurance
-    @simulation_date = simulation_date
+  def initialize(param_parser)
+    @from = param_parser.retirement_month
+    @to = param_parser.employment_month
+    @salary = param_parser.salary
+    @social_insurance = param_parser.social_insurance
+    @scheduled_salary = param_parser.scheduled_salary
+    @scheduled_social_insurance = param_parser.scheduled_social_insurance
+    @simulation_date = param_parser.simulation_date
   end
 
   def call
@@ -138,4 +137,3 @@ class Simulation::Residence
 end
 
 # rubocop:enable Metrics/ClassLength
-# rubocop:enable Metrics/ParameterLists

--- a/app/models/simulation/residence.rb
+++ b/app/models/simulation/residence.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
-
 class Simulation::Residence
   BASIC_DEDUCTION = 430_000
   PREFECTURE_CAPITA_BASIS = 1_500
@@ -20,11 +18,8 @@ class Simulation::Residence
   def initialize(param_parser)
     @from = param_parser.retirement_month
     @to = param_parser.employment_month
-    @salary = param_parser.salary
-    @social_insurance = param_parser.social_insurance
-    @scheduled_salary = param_parser.scheduled_salary
-    @scheduled_social_insurance = param_parser.scheduled_social_insurance
-    @simulation_date = param_parser.simulation_date
+    @salary_table = param_parser.salary_table
+    @social_insurance_table = param_parser.social_insurance_table
   end
 
   def call
@@ -33,7 +28,7 @@ class Simulation::Residence
 
   private
 
-  attr_reader :from, :to, :salary, :social_insurance, :scheduled_salary, :scheduled_social_insurance, :simulation_date
+  attr_reader :from, :to, :salary_table, :social_insurance_table, :scheduled_salary, :scheduled_social_insurance
 
   def monthly_residence
     fiscal_years.flat_map do |year|
@@ -116,24 +111,4 @@ class Simulation::Residence
   def income_deduction(year)
     social_insurance_table[year] + BASIC_DEDUCTION
   end
-
-  def salary_table
-    {
-      base_fiscal_year => salary,
-      base_fiscal_year.next => scheduled_salary
-    }
-  end
-
-  def social_insurance_table
-    {
-      base_fiscal_year => social_insurance,
-      base_fiscal_year.next => scheduled_social_insurance
-    }
-  end
-
-  def base_fiscal_year
-    simulation_date.financial_year
-  end
 end
-
-# rubocop:enable Metrics/ClassLength

--- a/spec/models/simulation/insurance_spec.rb
+++ b/spec/models/simulation/insurance_spec.rb
@@ -4,11 +4,17 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Insurance, type: :model do
   describe '.call' do
-    subject { Simulation::Insurance.call(retirement_month, employment_month, '131016', 40, simulation_date, salary, scheduled_salary) }
-    # FIXME: 変更する必要がなければ、固定値で呼び出す。
-    let!(:simulation_date) { Time.zone.parse('2021-04-11') }
-    let!(:salary) { 5_000_000 }
-    let!(:scheduled_salary) { 5_000_000 }
+    subject { Simulation::Insurance.call(param_parser) }
+    let(:param_parser) do
+      double(
+        'ParamParser',
+        retirement_month: retirement_month,
+        employment_month: employment_month,
+        local_gov_code: '131016',
+        age: 40,
+        salary_table: { 2021 => 5_000_000, 2022 => 5_000_000 }
+      )
+    end
 
     context 'when cross the year before employment' do
       let!(:retirement_month) { Time.zone.parse('2021-04-01') }

--- a/spec/models/simulation/pension_spec.rb
+++ b/spec/models/simulation/pension_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Pension, type: :model do
   describe '.call' do
-    subject { Simulation::Pension.call(from, to) }
+    subject { Simulation::Pension.call(param_parser) }
+    let(:param_parser) { double('ParamParser', retirement_month: from, employment_month: to) }
 
     context 'when Pension record for the specified year is exist' do
       before do

--- a/spec/models/simulation/residence_spec.rb
+++ b/spec/models/simulation/residence_spec.rb
@@ -4,11 +4,16 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Residence, type: :model do
   describe '.call' do
-    subject do
-      Simulation::Residence.call(retirement_month, employment_month, salary, social_insurance, scheduled_salary, scheduled_social_insurance, simulation_date)
+    subject { Simulation::Residence.call(param_parser) }
+    let(:param_parser) do
+      double(
+        'ParamParser',
+        retirement_month: retirement_month,
+        employment_month: employment_month,
+        salary_table: { 2021 => salary, 2022 => scheduled_salary },
+        social_insurance_table: { 2021 => social_insurance, 2022 => scheduled_social_insurance }
+      )
     end
-
-    let!(:simulation_date) { Time.zone.parse('2021-04-11') }
 
     context '給与収入が1,000,000より大きい場合' do
       let!(:salary) { 4_988_682 }


### PR DESCRIPTION
Closes #100

## やったこと

- コントローラーから受け渡されるパラメータについて、バケツリレーで受け渡しを行なっており、コードの見通し的にも記述量的にも好ましくなかったため、ParamParserクラスを受け渡すように変更
- パラメータから各クラスで導出していた給与、社会保険料についても重複していたため、ParamParser側の責務として抽出。各クラスに不要な引数を渡さないようにした。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
