### PR TITLE
地方税法に則った端数処理モジュールを作成

### DIFF
--- a/app/models/concerns/local_tax_law.rb
+++ b/app/models/concerns/local_tax_law.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module LocalTaxLaw
+  extend self
+
+  # 第二十条の四の二 第一項
+  def calc_tax_base(&process)
+    result = yield process
+    result.floor(-3)
+  end
+
+  # 第二十条の四の二 第三項
+  # 住民税と国民健康保険は「政令で定める地方税」に相当しないため簡素化して実装
+  def calc_determined_amount(&process)
+    result = yield process
+    result.floor(-2)
+  end
+
+  # 第二十条の四の二 第六項
+  def calc_installments(total, dues, municipal_ordinance: false, special_insurance: false)
+    number_of_payments = dues.size
+    digits = calc_digits(municipal_ordinance, special_insurance)
+    not_first_month = (total / number_of_payments).floor(digits)
+    first_month = total - not_first_month * (number_of_payments - 1)
+    [first_month, Array.new(number_of_payments - 1) { not_first_month }].flatten
+  end
+
+  private
+
+  # 第二十条の四の二 第九項（特別徴収の国民保険）および第二十条の四の二 第六項（条例の定める範囲）
+  def calc_digits(municipal_ordinance, special_insurance)
+    municipal_ordinance || special_insurance ? -2 : -3
+  end
+end

--- a/spec/models/simulation/insurance_spec.rb
+++ b/spec/models/simulation/insurance_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Simulation::Insurance, type: :model do
         expected = [
           { month: Time.zone.parse('2021-04-01'), insurance: 0 },
           { month: Time.zone.parse('2021-05-01'), insurance: 0 },
-          { month: Time.zone.parse('2021-06-01'), insurance: 39_250 },
+          { month: Time.zone.parse('2021-06-01'), insurance: 39_200 },
           { month: Time.zone.parse('2021-07-01'), insurance: 39_100 },
           { month: Time.zone.parse('2021-08-01'), insurance: 39_100 },
           { month: Time.zone.parse('2021-09-01'), insurance: 39_100 },
@@ -74,7 +74,7 @@ RSpec.describe Simulation::Insurance, type: :model do
           { month: Time.zone.parse('2022-03-01'), insurance: 39_100 },
           { month: Time.zone.parse('2022-04-01'), insurance: 0 },
           { month: Time.zone.parse('2022-05-01'), insurance: 0 },
-          { month: Time.zone.parse('2022-06-01'), insurance: 39_250 },
+          { month: Time.zone.parse('2022-06-01'), insurance: 39_200 },
           { month: Time.zone.parse('2022-07-01'), insurance: 39_100 },
           { month: Time.zone.parse('2022-08-01'), insurance: 39_100 },
           { month: Time.zone.parse('2022-09-01'), insurance: 39_100 },
@@ -127,7 +127,7 @@ RSpec.describe Simulation::Insurance, type: :model do
           care_limit: 170_000
         )
         expected = [
-          { month: Time.zone.parse('2021-04-01'), insurance: 39_250 },
+          { month: Time.zone.parse('2021-04-01'), insurance: 39_200 },
           { month: Time.zone.parse('2021-05-01'), insurance: 39_100 },
           { month: Time.zone.parse('2021-06-01'), insurance: 39_100 },
           { month: Time.zone.parse('2021-07-01'), insurance: 39_100 },
@@ -139,7 +139,7 @@ RSpec.describe Simulation::Insurance, type: :model do
           { month: Time.zone.parse('2022-01-01'), insurance: 39_100 },
           { month: Time.zone.parse('2022-02-01'), insurance: 0 },
           { month: Time.zone.parse('2022-03-01'), insurance: 0 },
-          { month: Time.zone.parse('2022-04-01'), insurance: 39_250 },
+          { month: Time.zone.parse('2022-04-01'), insurance: 39_200 },
           { month: Time.zone.parse('2022-05-01'), insurance: 39_100 },
           { month: Time.zone.parse('2022-06-01'), insurance: 39_100 },
           { month: Time.zone.parse('2022-07-01'), insurance: 39_100 },
@@ -197,7 +197,7 @@ RSpec.describe Simulation::Insurance, type: :model do
           { month: Time.zone.parse('2021-04-01'), insurance: 0 },
           { month: Time.zone.parse('2021-05-01'), insurance: 0 },
           { month: Time.zone.parse('2021-06-01'), insurance: 0 },
-          { month: Time.zone.parse('2021-07-01'), insurance: 98_050 },
+          { month: Time.zone.parse('2021-07-01'), insurance: 98_000 },
           { month: Time.zone.parse('2021-08-01'), insurance: 0 },
           { month: Time.zone.parse('2021-09-01'), insurance: 97_700 },
           { month: Time.zone.parse('2021-10-01'), insurance: 0 },
@@ -209,7 +209,7 @@ RSpec.describe Simulation::Insurance, type: :model do
           { month: Time.zone.parse('2022-04-01'), insurance: 0 },
           { month: Time.zone.parse('2022-05-01'), insurance: 0 },
           { month: Time.zone.parse('2022-06-01'), insurance: 0 },
-          { month: Time.zone.parse('2022-07-01'), insurance: 98_050 },
+          { month: Time.zone.parse('2022-07-01'), insurance: 98_000 },
           { month: Time.zone.parse('2022-08-01'), insurance: 0 },
           { month: Time.zone.parse('2022-09-01'), insurance: 97_700 },
           { month: Time.zone.parse('2022-10-01'), insurance: 0 },
@@ -264,7 +264,7 @@ RSpec.describe Simulation::Insurance, type: :model do
           { month: Time.zone.parse('2021-04-01'), insurance: 0 },
           { month: Time.zone.parse('2021-05-01'), insurance: 0 },
           { month: Time.zone.parse('2021-06-01'), insurance: 0 },
-          { month: Time.zone.parse('2021-07-01'), insurance: 98_050 },
+          { month: Time.zone.parse('2021-07-01'), insurance: 98_000 },
           { month: Time.zone.parse('2021-08-01'), insurance: 0 },
           { month: Time.zone.parse('2021-09-01'), insurance: 97_700 },
           { month: Time.zone.parse('2021-10-01'), insurance: 97_700 },
@@ -276,7 +276,7 @@ RSpec.describe Simulation::Insurance, type: :model do
           { month: Time.zone.parse('2022-04-01'), insurance: 0 },
           { month: Time.zone.parse('2022-05-01'), insurance: 0 },
           { month: Time.zone.parse('2022-06-01'), insurance: 0 },
-          { month: Time.zone.parse('2022-07-01'), insurance: 98_050 },
+          { month: Time.zone.parse('2022-07-01'), insurance: 98_000 },
           { month: Time.zone.parse('2022-08-01'), insurance: 0 },
           { month: Time.zone.parse('2022-09-01'), insurance: 97_700 },
           { month: Time.zone.parse('2022-10-01'), insurance: 97_700 },
@@ -317,7 +317,7 @@ RSpec.describe Simulation::Insurance, type: :model do
           expected = [
             { month: Time.zone.parse('2021-04-01'), insurance: 0 },
             { month: Time.zone.parse('2021-05-01'), insurance: 0 },
-            { month: Time.zone.parse('2021-06-01'), insurance: 39_250 },
+            { month: Time.zone.parse('2021-06-01'), insurance: 39_200 },
             { month: Time.zone.parse('2021-07-01'), insurance: 39_100 },
             { month: Time.zone.parse('2021-08-01'), insurance: 39_100 },
             { month: Time.zone.parse('2021-09-01'), insurance: 39_100 },
@@ -351,7 +351,7 @@ RSpec.describe Simulation::Insurance, type: :model do
             care_limit: 170_000
           )
           expected = [
-            { month: Time.zone.parse('2021-04-01'), insurance: 39_250 },
+            { month: Time.zone.parse('2021-04-01'), insurance: 39_200 },
             { month: Time.zone.parse('2021-05-01'), insurance: 39_100 },
             { month: Time.zone.parse('2021-06-01'), insurance: 39_100 },
             { month: Time.zone.parse('2021-07-01'), insurance: 39_100 },
@@ -390,7 +390,7 @@ RSpec.describe Simulation::Insurance, type: :model do
             { month: Time.zone.parse('2021-04-01'), insurance: 0 },
             { month: Time.zone.parse('2021-05-01'), insurance: 0 },
             { month: Time.zone.parse('2021-06-01'), insurance: 0 },
-            { month: Time.zone.parse('2021-07-01'), insurance: 98_050 },
+            { month: Time.zone.parse('2021-07-01'), insurance: 98_000 },
             { month: Time.zone.parse('2021-08-01'), insurance: 0 },
             { month: Time.zone.parse('2021-09-01'), insurance: 97_700 },
             { month: Time.zone.parse('2021-10-01'), insurance: 0 },
@@ -426,7 +426,7 @@ RSpec.describe Simulation::Insurance, type: :model do
             { month: Time.zone.parse('2021-04-01'), insurance: 0 },
             { month: Time.zone.parse('2021-05-01'), insurance: 0 },
             { month: Time.zone.parse('2021-06-01'), insurance: 0 },
-            { month: Time.zone.parse('2021-07-01'), insurance: 98_050 },
+            { month: Time.zone.parse('2021-07-01'), insurance: 98_000 },
             { month: Time.zone.parse('2021-08-01'), insurance: 0 },
             { month: Time.zone.parse('2021-09-01'), insurance: 97_700 },
             { month: Time.zone.parse('2021-10-01'), insurance: 97_700 },
@@ -466,7 +466,7 @@ RSpec.describe Simulation::Insurance, type: :model do
           expected = [
             { month: Time.zone.parse('2022-04-01'), insurance: 0 },
             { month: Time.zone.parse('2022-05-01'), insurance: 0 },
-            { month: Time.zone.parse('2022-06-01'), insurance: 39_250 },
+            { month: Time.zone.parse('2022-06-01'), insurance: 39_200 },
             { month: Time.zone.parse('2022-07-01'), insurance: 39_100 },
             { month: Time.zone.parse('2022-08-01'), insurance: 39_100 },
             { month: Time.zone.parse('2022-09-01'), insurance: 39_100 },
@@ -500,7 +500,7 @@ RSpec.describe Simulation::Insurance, type: :model do
             care_limit: 170_000
           )
           expected = [
-            { month: Time.zone.parse('2022-04-01'), insurance: 39_250 },
+            { month: Time.zone.parse('2022-04-01'), insurance: 39_200 },
             { month: Time.zone.parse('2022-05-01'), insurance: 39_100 },
             { month: Time.zone.parse('2022-06-01'), insurance: 39_100 },
             { month: Time.zone.parse('2022-07-01'), insurance: 39_100 },
@@ -539,7 +539,7 @@ RSpec.describe Simulation::Insurance, type: :model do
             { month: Time.zone.parse('2022-04-01'), insurance: 0 },
             { month: Time.zone.parse('2022-05-01'), insurance: 0 },
             { month: Time.zone.parse('2022-06-01'), insurance: 0 },
-            { month: Time.zone.parse('2022-07-01'), insurance: 98_050 },
+            { month: Time.zone.parse('2022-07-01'), insurance: 98_000 },
             { month: Time.zone.parse('2022-08-01'), insurance: 0 },
             { month: Time.zone.parse('2022-09-01'), insurance: 97_700 },
             { month: Time.zone.parse('2022-10-01'), insurance: 0 },
@@ -575,7 +575,7 @@ RSpec.describe Simulation::Insurance, type: :model do
             { month: Time.zone.parse('2022-04-01'), insurance: 0 },
             { month: Time.zone.parse('2022-05-01'), insurance: 0 },
             { month: Time.zone.parse('2022-06-01'), insurance: 0 },
-            { month: Time.zone.parse('2022-07-01'), insurance: 98_050 },
+            { month: Time.zone.parse('2022-07-01'), insurance: 98_000 },
             { month: Time.zone.parse('2022-08-01'), insurance: 0 },
             { month: Time.zone.parse('2022-09-01'), insurance: 97_700 },
             { month: Time.zone.parse('2022-10-01'), insurance: 97_700 },

--- a/spec/models/simulation/residence_spec.rb
+++ b/spec/models/simulation/residence_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe Simulation::Residence, type: :model do
 
               it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になること' do
                 expected = [
-                  { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                  { month: Time.zone.parse('2021-06-01'), residence: 60_700 },
                   { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2021-08-01'), residence: 60_000 },
                   { month: Time.zone.parse('2021-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2021-10-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 60_000 },
                   { month: Time.zone.parse('2021-11-01'), residence: 0 },
                   { month: Time.zone.parse('2021-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-01-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 60_000 },
                   { month: Time.zone.parse('2022-02-01'), residence: 0 },
                   { month: Time.zone.parse('2022-03-01'), residence: 0 },
                   { month: Time.zone.parse('2022-04-01'), residence: 0 },
@@ -68,12 +68,12 @@ RSpec.describe Simulation::Residence, type: :model do
               it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になること' do
                 expected = [
                   { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                  { month: Time.zone.parse('2021-08-01'), residence: 74_000 },
                   { month: Time.zone.parse('2021-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 73_000 },
                   { month: Time.zone.parse('2021-11-01'), residence: 0 },
                   { month: Time.zone.parse('2021-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-01-01'), residence: 73_300 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 73_000 },
                   { month: Time.zone.parse('2022-02-01'), residence: 0 },
                   { month: Time.zone.parse('2022-03-01'), residence: 0 },
                   { month: Time.zone.parse('2022-04-01'), residence: 0 },
@@ -132,14 +132,14 @@ RSpec.describe Simulation::Residence, type: :model do
                 { month: Time.zone.parse('2022-03-01'), residence: 0 },
                 { month: Time.zone.parse('2022-04-01'), residence: 0 },
                 { month: Time.zone.parse('2022-05-01'), residence: 0 },
-                { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                { month: Time.zone.parse('2022-06-01'), residence: 30_500 },
                 { month: Time.zone.parse('2022-07-01'), residence: 0 },
-                { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                { month: Time.zone.parse('2022-08-01'), residence: 27_000 },
                 { month: Time.zone.parse('2022-09-01'), residence: 0 },
-                { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                { month: Time.zone.parse('2022-10-01'), residence: 27_000 },
                 { month: Time.zone.parse('2022-11-01'), residence: 0 },
                 { month: Time.zone.parse('2022-12-01'), residence: 0 },
-                { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                { month: Time.zone.parse('2023-01-01'), residence: 27_000 },
                 { month: Time.zone.parse('2023-02-01'), residence: 0 },
                 { month: Time.zone.parse('2023-03-01'), residence: 0 }
               ]
@@ -155,26 +155,26 @@ RSpec.describe Simulation::Residence, type: :model do
 
               it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になること、翌年度の住民税が普通徴収されること' do
                 expected = [
-                  { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                  { month: Time.zone.parse('2021-06-01'), residence: 60_700 },
                   { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2021-08-01'), residence: 60_000 },
                   { month: Time.zone.parse('2021-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2021-10-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 60_000 },
                   { month: Time.zone.parse('2021-11-01'), residence: 0 },
                   { month: Time.zone.parse('2021-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-01-01'), residence: 60_100 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 60_000 },
                   { month: Time.zone.parse('2022-02-01'), residence: 0 },
                   { month: Time.zone.parse('2022-03-01'), residence: 0 },
                   { month: Time.zone.parse('2022-04-01'), residence: 0 },
                   { month: Time.zone.parse('2022-05-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-06-01'), residence: 30_500 },
                   { month: Time.zone.parse('2022-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-11-01'), residence: 0 },
                   { month: Time.zone.parse('2022-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_000 },
                   { month: Time.zone.parse('2023-02-01'), residence: 0 },
                   { month: Time.zone.parse('2023-03-01'), residence: 0 }
                 ]
@@ -188,24 +188,24 @@ RSpec.describe Simulation::Residence, type: :model do
               it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になること、翌年度の住民税が普通徴収されること' do
                 expected = [
                   { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                  { month: Time.zone.parse('2021-08-01'), residence: 74_000 },
                   { month: Time.zone.parse('2021-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+                  { month: Time.zone.parse('2021-10-01'), residence: 73_000 },
                   { month: Time.zone.parse('2021-11-01'), residence: 0 },
                   { month: Time.zone.parse('2021-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-01-01'), residence: 73_300 },
+                  { month: Time.zone.parse('2022-01-01'), residence: 73_000 },
                   { month: Time.zone.parse('2022-02-01'), residence: 0 },
                   { month: Time.zone.parse('2022-03-01'), residence: 0 },
                   { month: Time.zone.parse('2022-04-01'), residence: 0 },
                   { month: Time.zone.parse('2022-05-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-06-01'), residence: 30_500 },
                   { month: Time.zone.parse('2022-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-11-01'), residence: 0 },
                   { month: Time.zone.parse('2022-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_000 },
                   { month: Time.zone.parse('2023-02-01'), residence: 0 },
                   { month: Time.zone.parse('2023-03-01'), residence: 0 }
                 ]
@@ -227,14 +227,14 @@ RSpec.describe Simulation::Residence, type: :model do
                   { month: Time.zone.parse('2022-03-01'), residence: 0 },
                   { month: Time.zone.parse('2022-04-01'), residence: 0 },
                   { month: Time.zone.parse('2022-05-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-06-01'), residence: 30_500 },
                   { month: Time.zone.parse('2022-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-11-01'), residence: 0 },
                   { month: Time.zone.parse('2022-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_000 },
                   { month: Time.zone.parse('2023-02-01'), residence: 0 },
                   { month: Time.zone.parse('2023-03-01'), residence: 0 }
                 ]
@@ -253,14 +253,14 @@ RSpec.describe Simulation::Residence, type: :model do
                   { month: Time.zone.parse('2022-03-01'), residence: 0 },
                   { month: Time.zone.parse('2022-04-01'), residence: 0 },
                   { month: Time.zone.parse('2022-05-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-06-01'), residence: 30_500 },
                   { month: Time.zone.parse('2022-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-11-01'), residence: 0 },
                   { month: Time.zone.parse('2022-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_000 },
                   { month: Time.zone.parse('2023-02-01'), residence: 0 },
                   { month: Time.zone.parse('2023-03-01'), residence: 0 }
                 ]
@@ -278,7 +278,7 @@ RSpec.describe Simulation::Residence, type: :model do
 
             it '該当年度の1月~5月分の特別徴収額が、退職月に一括請求されること' do
               expected = [
-                { month: Time.zone.parse('2023-02-01'), residence: 36_800 },
+                { month: Time.zone.parse('2023-02-01'), residence: 36_000 },
                 { month: Time.zone.parse('2023-03-01'), residence: 0 }
               ]
               expect(subject).to eq expected
@@ -293,14 +293,14 @@ RSpec.describe Simulation::Residence, type: :model do
 
               it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になること' do
                 expected = [
-                  { month: Time.zone.parse('2022-06-01'), residence: 28_100 },
+                  { month: Time.zone.parse('2022-06-01'), residence: 30_500 },
                   { month: Time.zone.parse('2022-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-08-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-10-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 27_000 },
                   { month: Time.zone.parse('2022-11-01'), residence: 0 },
                   { month: Time.zone.parse('2022-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2023-01-01'), residence: 27_800 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 27_000 },
                   { month: Time.zone.parse('2023-02-01'), residence: 0 },
                   { month: Time.zone.parse('2023-03-01'), residence: 0 }
                 ]
@@ -314,12 +314,12 @@ RSpec.describe Simulation::Residence, type: :model do
               it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になること' do
                 expected = [
                   { month: Time.zone.parse('2022-07-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-08-01'), residence: 33_800 },
+                  { month: Time.zone.parse('2022-08-01'), residence: 33_000 },
                   { month: Time.zone.parse('2022-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-10-01'), residence: 33_700 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 33_000 },
                   { month: Time.zone.parse('2022-11-01'), residence: 0 },
                   { month: Time.zone.parse('2022-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2023-01-01'), residence: 33_700 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 33_000 },
                   { month: Time.zone.parse('2023-02-01'), residence: 0 },
                   { month: Time.zone.parse('2023-03-01'), residence: 0 }
                 ]
@@ -333,10 +333,10 @@ RSpec.describe Simulation::Residence, type: :model do
               it '該当年度の退職~5月分の特別徴収額が、10月と1月で分納になること' do
                 expected = [
                   { month: Time.zone.parse('2022-09-01'), residence: 0 },
-                  { month: Time.zone.parse('2022-10-01'), residence: 41_400 },
+                  { month: Time.zone.parse('2022-10-01'), residence: 41_000 },
                   { month: Time.zone.parse('2022-11-01'), residence: 0 },
                   { month: Time.zone.parse('2022-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2023-01-01'), residence: 41_400 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 40_000 },
                   { month: Time.zone.parse('2023-02-01'), residence: 0 },
                   { month: Time.zone.parse('2023-03-01'), residence: 0 }
                 ]
@@ -350,7 +350,7 @@ RSpec.describe Simulation::Residence, type: :model do
               it '該当年度の退職~5月の特別徴収分が、1月に支払になること' do
                 expected = [
                   { month: Time.zone.parse('2022-12-01'), residence: 0 },
-                  { month: Time.zone.parse('2023-01-01'), residence: 55_200 },
+                  { month: Time.zone.parse('2023-01-01'), residence: 54_000 },
                   { month: Time.zone.parse('2023-02-01'), residence: 0 },
                   { month: Time.zone.parse('2023-03-01'), residence: 0 }
                 ]
@@ -387,7 +387,7 @@ RSpec.describe Simulation::Residence, type: :model do
 
                 it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になり、6月のみ支払対象とすること' do
                   expected = [
-                    { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                    { month: Time.zone.parse('2021-06-01'), residence: 60_700 },
                     { month: Time.zone.parse('2021-07-01'), residence: 0 }
                   ]
                   expect(subject).to eq expected
@@ -399,9 +399,9 @@ RSpec.describe Simulation::Residence, type: :model do
 
                 it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になり、6、8月分を支払対象とすること' do
                   expected = [
-                    { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                    { month: Time.zone.parse('2021-06-01'), residence: 60_700 },
                     { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 60_000 },
                     { month: Time.zone.parse('2021-09-01'), residence: 0 }
                   ]
                   expect(subject).to eq expected
@@ -413,11 +413,11 @@ RSpec.describe Simulation::Residence, type: :model do
 
                 it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になり、6、8、10月分を支払対象とすること' do
                   expected = [
-                    { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                    { month: Time.zone.parse('2021-06-01'), residence: 60_700 },
                     { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 60_000 },
                     { month: Time.zone.parse('2021-09-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-10-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 60_000 },
                     { month: Time.zone.parse('2021-11-01'), residence: 0 },
                     { month: Time.zone.parse('2021-12-01'), residence: 0 }
                   ]
@@ -430,14 +430,14 @@ RSpec.describe Simulation::Residence, type: :model do
 
                 it '該当年度の退職~5月分の特別徴収額が、6,8,10,1月で分納になり、6、8、10、1月分を支払対象とすること' do
                   expected = [
-                    { month: Time.zone.parse('2021-06-01'), residence: 60_400 },
+                    { month: Time.zone.parse('2021-06-01'), residence: 60_700 },
                     { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-08-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 60_000 },
                     { month: Time.zone.parse('2021-09-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-10-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 60_000 },
                     { month: Time.zone.parse('2021-11-01'), residence: 0 },
                     { month: Time.zone.parse('2021-12-01'), residence: 0 },
-                    { month: Time.zone.parse('2022-01-01'), residence: 60_100 },
+                    { month: Time.zone.parse('2022-01-01'), residence: 60_000 },
                     { month: Time.zone.parse('2022-02-01'), residence: 0 },
                     { month: Time.zone.parse('2022-03-01'), residence: 0 },
                     { month: Time.zone.parse('2022-04-01'), residence: 0 }
@@ -468,7 +468,7 @@ RSpec.describe Simulation::Residence, type: :model do
                 it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になり、8月分を支払対象とすること' do
                   expected = [
                     { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 74_000 },
                     { month: Time.zone.parse('2021-09-01'), residence: 0 }
                   ]
                   expect(subject).to eq expected
@@ -481,9 +481,9 @@ RSpec.describe Simulation::Residence, type: :model do
                 it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になり、8、10月分を支払対象とすること' do
                   expected = [
                     { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 74_000 },
                     { month: Time.zone.parse('2021-09-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 73_000 },
                     { month: Time.zone.parse('2021-11-01'), residence: 0 },
                     { month: Time.zone.parse('2021-12-01'), residence: 0 }
                   ]
@@ -497,12 +497,12 @@ RSpec.describe Simulation::Residence, type: :model do
                 it '該当年度の退職~5月分の特別徴収額が、8,10,1月で分納になり、8、10、1月分を支払対象とすること' do
                   expected = [
                     { month: Time.zone.parse('2021-07-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+                    { month: Time.zone.parse('2021-08-01'), residence: 74_000 },
                     { month: Time.zone.parse('2021-09-01'), residence: 0 },
-                    { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+                    { month: Time.zone.parse('2021-10-01'), residence: 73_000 },
                     { month: Time.zone.parse('2021-11-01'), residence: 0 },
                     { month: Time.zone.parse('2021-12-01'), residence: 0 },
-                    { month: Time.zone.parse('2022-01-01'), residence: 73_300 },
+                    { month: Time.zone.parse('2022-01-01'), residence: 73_000 },
                     { month: Time.zone.parse('2022-02-01'), residence: 0 },
                     { month: Time.zone.parse('2022-03-01'), residence: 0 },
                     { month: Time.zone.parse('2022-04-01'), residence: 0 }
@@ -599,17 +599,17 @@ RSpec.describe Simulation::Residence, type: :model do
           it '退職年度の金額が普通徴収として残りの納期に按分され、翌年度の料金は普通徴収として計算した上で就職する前月まで支払義務が発生すること' do
             expected = [
               { month: Time.zone.parse('2021-07-01'), residence: 0 },
-              { month: Time.zone.parse('2021-08-01'), residence: 73_400 },
+              { month: Time.zone.parse('2021-08-01'), residence: 74_000 },
               { month: Time.zone.parse('2021-09-01'), residence: 0 },
-              { month: Time.zone.parse('2021-10-01'), residence: 73_300 },
+              { month: Time.zone.parse('2021-10-01'), residence: 73_000 },
               { month: Time.zone.parse('2021-11-01'), residence: 0 },
               { month: Time.zone.parse('2021-12-01'), residence: 0 },
-              { month: Time.zone.parse('2022-01-01'), residence: 73_300 },
+              { month: Time.zone.parse('2022-01-01'), residence: 73_000 },
               { month: Time.zone.parse('2022-02-01'), residence: 0 },
               { month: Time.zone.parse('2022-03-01'), residence: 0 },
               { month: Time.zone.parse('2022-04-01'), residence: 0 },
               { month: Time.zone.parse('2022-05-01'), residence: 0 },
-              { month: Time.zone.parse('2022-06-01'), residence: 28_100 }
+              { month: Time.zone.parse('2022-06-01'), residence: 30_500 }
             ]
             expect(subject).to eq expected
           end
@@ -622,9 +622,9 @@ RSpec.describe Simulation::Residence, type: :model do
           it '退職年度の金額が普通徴収として残りの納期に按分され、翌年度の料金は普通徴収として計算した上で就職する前月まで支払義務が発生すること' do
             expected = [
               { month: Time.zone.parse('2022-07-01'), residence: 0 },
-              { month: Time.zone.parse('2022-08-01'), residence: 33_800 },
+              { month: Time.zone.parse('2022-08-01'), residence: 33_000 },
               { month: Time.zone.parse('2022-09-01'), residence: 0 },
-              { month: Time.zone.parse('2022-10-01'), residence: 33_700 }
+              { month: Time.zone.parse('2022-10-01'), residence: 33_000 }
             ]
             expect(subject).to eq expected
           end


### PR DESCRIPTION
Closes #99

## 目的

住民税、国民健康保険税に対する端数処理は地方税法で決まっている。
ロジックの明確化と処理の共通化のために端数処理をモジュールとして定義する。

## やったこと

- 地方税法「第二十条の四の二」で定義されている端数処理をModule`LocalTaxLaw`として定義
    - 参考：https://elaws.e-gov.go.jp/document?lawid=325AC0000000226
- 地方税法の端数処理に合わせて、これまで誤認していた計算によるテストの期待値を修正
    - （第二十条の四の二 第一項）特殊な端数処理は行っていなかったが、条例に合わせて端数処理を追加した
    - （第二十条の四の二 第六項）住民税の複数納期における端数計算について、百円未満を初月にまとめるように誤認していたが、地方税法第二十条の四の二 第六項に則り、千円未満を初月にまとめた結果でテストの値を修正した。また国民健康保険については、多くの市区町村で条例により端数処理が「100円未満」に上書きされているため、
このアプリの仕様として100円未満で計算するように設定した

## 申し送り事項

### 第二十条の四の二 第三項

> 地方税の確定金額に百円未満の端数があるとき、又はその全額が百円未満であるときは、その端数金額又はその全額を切り捨てる。ただし、政令で定める地方税の確定金額については、その額に一円未満の端数があるとき、又はその全額が一円未満であるときは、その端数金額又はその全額を切り捨てる。

「確定金額」については、[地方団体の徴収金の端数計算等について](https://www.mhlw.go.jp/web/t_doc?dataId=00tb0627&dataType=1&pageNo=1#:~:text=%E9%87%91%E9%A1%8D%E3%81%AE%E6%84%8F%E7%BE%A9-,%E6%B3%95%E7%AC%AC%E4%BA%8C%E3%80%87%E6%9D%A1%E3%81%AE%E5%9B%9B%E3%81%AE%E4%BA%8C%E7%AC%AC,%E3%81%AE%E3%81%93%E3%81%A8%E3%81%AB%E7%95%99%E6%84%8F%E3%81%99%E3%82%8B%E3%80%82)の「5. 確定金額の意義」を根拠として、「最終的に発生する支払金額」と判断し、途中計算（国民健康保険の医療分や介護分など）には適用せず、国民健康保険料・住民税の年間支払額に適用することとした。

### 第二十条の四の二 第六項

端数処理のケースは3通り

1. 国民健康保険税の特別徴収: 100円未満を切り捨て（同条 第九項）
2. 条例で制定がある場合： 条例が指定する桁で切り捨て
3. 上記以外の場合： 1000円未満を切り捨て

忠実に実装するのであれば、2の条例で定めるケースへの対応として、任意の桁数を引数にとる。
今回はアプリとして100円未満 or 1000円未満の切り捨てにのみ対応することとしたこと、LocalTaxRawに法律関連の責務を閉じ込める目的で、フラグによる限定的な実装とした。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
