### PR TITLE
simulation系クラスのAPIをcalcに変更

### DIFF
--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -38,14 +38,14 @@ class Simulation
   attr_reader :param_parser
 
   def insurance
-    Simulation::Insurance.call(param_parser)
+    Simulation::Insurance.calc(param_parser)
   end
 
   def pension
-    Simulation::Pension.call(param_parser)
+    Simulation::Pension.calc(param_parser)
   end
 
   def residence
-    Simulation::Residence.call(param_parser)
+    Simulation::Residence.calc(param_parser)
   end
 end

--- a/app/models/simulation/insurance.rb
+++ b/app/models/simulation/insurance.rb
@@ -3,8 +3,8 @@
 class Simulation::Insurance
   include MonthIterable
 
-  def self.call(param_parser)
-    new(param_parser).call
+  def self.calc(param_parser)
+    new(param_parser).calc
   end
 
   def initialize(param_parser)
@@ -15,7 +15,7 @@ class Simulation::Insurance
     @salary_table = param_parser.salary_table
   end
 
-  def call
+  def calc
     monthly_insurance
   end
 
@@ -62,14 +62,14 @@ class Simulation::Insurance
   end
 
   def calculate_medical(year, salary)
-    Simulation::Insurance::Medical.call(year: year, local_gov_code: local_gov_code, income: salary, age: age)
+    Simulation::Insurance::Medical.calc(year: year, local_gov_code: local_gov_code, income: salary, age: age)
   end
 
   def calculate_elderly(year, salary)
-    Simulation::Insurance::Elderly.call(year: year, local_gov_code: local_gov_code, income: salary, age: age)
+    Simulation::Insurance::Elderly.calc(year: year, local_gov_code: local_gov_code, income: salary, age: age)
   end
 
   def calculate_care(year, salary)
-    Simulation::Insurance::Care.call(year: year, local_gov_code: local_gov_code, income: salary, age: age)
+    Simulation::Insurance::Care.calc(year: year, local_gov_code: local_gov_code, income: salary, age: age)
   end
 end

--- a/app/models/simulation/insurance/base.rb
+++ b/app/models/simulation/insurance/base.rb
@@ -3,8 +3,8 @@
 class Simulation::Insurance::Base
   BASIC_DEDUCTION = 430_000
 
-  def self.call(year:, local_gov_code:, income:, age:)
-    new(year, local_gov_code, income, age).call
+  def self.calc(year:, local_gov_code:, income:, age:)
+    new(year, local_gov_code, income, age).calc
   end
 
   def initialize(year, local_gov_code, income, age)
@@ -13,7 +13,7 @@ class Simulation::Insurance::Base
     @age = age
   end
 
-  def call
+  def calc
     calculate
   end
 
@@ -49,7 +49,7 @@ class Simulation::Insurance::Base
   end
 
   def salary
-    candidate = Simulation::Salary.call(@income) - BASIC_DEDUCTION
+    candidate = Simulation::Salary.calc(@income) - BASIC_DEDUCTION
     candidate.positive? ? candidate : 0
   end
 end

--- a/app/models/simulation/pension.rb
+++ b/app/models/simulation/pension.rb
@@ -3,7 +3,7 @@
 class Simulation::Pension
   include MonthIterable
 
-  def self.call(param_parser)
+  def self.calc(param_parser)
     new(param_parser).call
   end
 

--- a/app/models/simulation/residence.rb
+++ b/app/models/simulation/residence.rb
@@ -26,8 +26,8 @@ class Simulation::Residence
   SPECIAL_COLLECTION_DUES = (1..12).to_a.freeze
   NON_TAXABLE_SALARY_LIMIT = 1_000_000
 
-  def self.call(param_parser)
-    new(param_parser).call
+  def self.calc(param_parser)
+    new(param_parser).calc
   end
 
   def initialize(param_parser)
@@ -37,7 +37,7 @@ class Simulation::Residence
     @social_insurance_table = param_parser.social_insurance_table
   end
 
-  def call
+  def calc
     monthly_residence
   end
 
@@ -109,7 +109,7 @@ class Simulation::Residence
   end
 
   def total_income(year)
-    Simulation::Salary.call(salary_table[year])
+    Simulation::Salary.calc(salary_table[year])
   end
 
   def income_deduction(year)

--- a/app/models/simulation/salary.rb
+++ b/app/models/simulation/salary.rb
@@ -15,15 +15,15 @@ class Simulation::Salary
     8_500_000.. => { plus: -1_950_000, multiply: 1, divide: 1 }
   }.freeze
 
-  def self.call(income)
-    new(income).call
+  def self.calc(income)
+    new(income).calc
   end
 
   def initialize(income)
     @income = income
   end
 
-  def call
+  def calc
     calculate_salary
   end
 

--- a/spec/models/simulation/insurance/care_spec.rb
+++ b/spec/models/simulation/insurance/care_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Insurance::Care, type: :model do
   describe '.call' do
-    subject { Simulation::Insurance::Care.call(year: year, local_gov_code: local_gov_code, income: income, age: age) }
+    subject { Simulation::Insurance::Care.calc(year: year, local_gov_code: local_gov_code, income: income, age: age) }
     let!(:year) { 2021 }
     let!(:local_gov_code) { '131016' }
     let!(:insurance) do

--- a/spec/models/simulation/insurance/elderly_spec.rb
+++ b/spec/models/simulation/insurance/elderly_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Insurance::Elderly, type: :model do
   describe '.call' do
-    subject { Simulation::Insurance::Elderly.call(year: year, local_gov_code: local_gov_code, income: income, age: age) }
+    subject { Simulation::Insurance::Elderly.calc(year: year, local_gov_code: local_gov_code, income: income, age: age) }
     let!(:year) { 2021 }
     let!(:local_gov_code) { '131016' }
     let!(:insurance) do

--- a/spec/models/simulation/insurance/medical_spec.rb
+++ b/spec/models/simulation/insurance/medical_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Insurance::Medical, type: :model do
   describe '.call' do
-    subject { Simulation::Insurance::Medical.call(year: year, local_gov_code: local_gov_code, income: income, age: age) }
+    subject { Simulation::Insurance::Medical.calc(year: year, local_gov_code: local_gov_code, income: income, age: age) }
     let!(:year) { 2021 }
     let!(:local_gov_code) { '131016' }
     let!(:insurance) do

--- a/spec/models/simulation/insurance_spec.rb
+++ b/spec/models/simulation/insurance_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Insurance, type: :model do
   describe '.call' do
-    subject { Simulation::Insurance.call(param_parser) }
+    subject { Simulation::Insurance.calc(param_parser) }
     let(:param_parser) do
       double(
         'ParamParser',

--- a/spec/models/simulation/pension_spec.rb
+++ b/spec/models/simulation/pension_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Pension, type: :model do
   describe '.call' do
-    subject { Simulation::Pension.call(param_parser) }
+    subject { Simulation::Pension.calc(param_parser) }
     let(:param_parser) { double('ParamParser', retirement_month: from, employment_month: to) }
 
     context 'when Pension record for the specified year is exist' do

--- a/spec/models/simulation/residence_spec.rb
+++ b/spec/models/simulation/residence_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Residence, type: :model do
   describe '.call' do
-    subject { Simulation::Residence.call(param_parser) }
+    subject { Simulation::Residence.calc(param_parser) }
     let(:param_parser) do
       double(
         'ParamParser',

--- a/spec/models/simulation/salary_spec.rb
+++ b/spec/models/simulation/salary_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Simulation::Salary, type: :model do
   # https://www.nta.go.jp/taxes/shiraberu/shinkoku/tebiki/2021/b/03/order2/3-2_06.htm
   describe '.call' do
-    subject { Simulation::Salary.call(income) }
+    subject { Simulation::Salary.calc(income) }
 
     context 'whole_income less than 551_000' do # 0
       let!(:income) { 550_999 }


### PR DESCRIPTION
Simulation系のクラスはすべてPOROで実装している。

「サービスオブジェクト等のPOROは慣習的にcallやexecでパブリックAPIを統一するべき」という言説に盲目的に従って従来は`call`を使用していた。

しかし以下の点からよりクラスが持つ責務に合わせた名前が好ましいと判断し、メソッド名のみを`call`から`calc`(calculate)に変更した。

- POROの設計とAPIの設計は別の論点である
- callはProcやMethodに対して実装されており、Rubyとして特別な意味がある
- Simulationに関する一連のクラスは「計算する」という明確な責務を持つ


---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
