### PR TITLE
Simulationの各フォームで使用していない変数とgetter/setterを削除

### DIFF
--- a/app/javascript/src/components/simulation_form/Age.vue
+++ b/app/javascript/src/components/simulation_form/Age.vue
@@ -4,7 +4,7 @@
     <input
       class="form-field text-right"
       type="text"
-      :value="ageValue"
+      :value="age"
       @blur="handleChange"
       placeholder="30"
     /><span class="form-supplement">歳</span>
@@ -13,18 +13,14 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { useGlobalStore } from '../../store/global'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
 
-const ageValue = computed({
-  get: () => age.value || params.age,
-  set: (value) => (age.value = value)
-})
 let { value: age, errorMessage: error, handleChange } = useField('age')
-const setDefaultValue = () => (age.value = params.age)
-setDefaultValue()
+
+onMounted(() => (age.value = params.age))
 </script>

--- a/app/javascript/src/components/simulation_form/EmploymentMonth.vue
+++ b/app/javascript/src/components/simulation_form/EmploymentMonth.vue
@@ -5,7 +5,7 @@
       class="form-field text-center"
       type="text"
       v-maska="{ mask: '####/##' }"
-      :value="employmentMonthValue"
+      :value="employmentMonth"
       @blur="handleChange"
       placeholder="2022/02"
     />
@@ -18,7 +18,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { addMonths, addYears, format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
@@ -32,10 +32,6 @@ const { endOfYear } = useFinancialYear(addYears(base, 1), 4)
 const from = format(base, 'yyyy/MM')
 const to = format(addMonths(endOfYear, 1), 'yyyy/MM')
 
-const employmentMonthValue = computed({
-  get: () => employmentMonth.value || params.employmentMonth,
-  set: (value) => (employmentMonth.value = value)
-})
 let { value: retirementMonth } = useField('retirementMonth')
 let {
   value: employmentMonth,

--- a/app/javascript/src/components/simulation_form/PostalCode.vue
+++ b/app/javascript/src/components/simulation_form/PostalCode.vue
@@ -7,7 +7,7 @@
       class="form-field text-center"
       type="text"
       v-maska="{ mask: '###-####' }"
-      v-model="postalCodeValue"
+      v-model="postalCode"
       @keyup="searchAddress"
       placeholder="100-0004"
     />
@@ -29,11 +29,6 @@ const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
 
 let { value: postalCode, errorMessage: error } = useField('postalCode')
-
-const postalCodeValue = computed({
-  get: () => postalCode.value || params.postalCode,
-  set: (value) => (postalCode.value = value)
-})
 
 const result = computed(() => {
   if (!postalCode.value) return `該当する市区町村がありません`

--- a/app/javascript/src/components/simulation_form/RetirementMonth.vue
+++ b/app/javascript/src/components/simulation_form/RetirementMonth.vue
@@ -5,7 +5,7 @@
       class="form-field text-center"
       type="text"
       v-maska="{ mask: '####/##' }"
-      :value="retirementMonthValue"
+      :value="retirementMonth"
       @blur="handleChange"
       placeholder="2022/02"
     />
@@ -18,7 +18,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { addMonths, addYears, format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
@@ -31,11 +31,6 @@ const base = new Date(params.simulationDate)
 const { endOfYear } = useFinancialYear(addYears(base, 1), 4)
 const from = format(base, 'yyyy/MM')
 const to = format(addMonths(endOfYear, 1), 'yyyy/MM')
-
-const retirementMonthValue = computed({
-  get: () => retirementMonth.value || params.retirementMonth,
-  set: (value) => (retirementMonth.value = value)
-})
 
 let {
   value: retirementMonth,

--- a/app/javascript/src/components/simulation_form/Salary.vue
+++ b/app/javascript/src/components/simulation_form/Salary.vue
@@ -7,7 +7,7 @@
     <input
       class="form-field text-right"
       type="text"
-      :value="salaryValue"
+      :value="salary"
       @blur="handleChange"
       v-maska="{ mask: '#*' }"
       placeholder="500000"
@@ -21,7 +21,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
@@ -29,11 +29,6 @@ import { useFinancialYear } from '../../composables/use-financial-year'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
-
-const salaryValue = computed({
-  get: () => salary.value || params.salary,
-  set: (value) => (salary.value = value)
-})
 
 const base = new Date(params.simulationDate)
 const { lastBeginningOfYear, lastEndOfYear } = useFinancialYear(base, 1, 4)

--- a/app/javascript/src/components/simulation_form/ScheduledSalary.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSalary.vue
@@ -7,7 +7,7 @@
     <input
       class="form-field text-right"
       type="text"
-      :value="scheduledSalaryValue"
+      :value="scheduledSalary"
       @blur="handleChange"
       v-maska="{ mask: '#*' }"
       placeholder="500000"
@@ -21,7 +21,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
@@ -29,11 +29,6 @@ import { useFinancialYear } from '../../composables/use-financial-year'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
-
-const scheduledSalaryValue = computed({
-  get: () => scheduledSalary.value || params.scheduledSalary,
-  set: (value) => (scheduledSalary.value = value)
-})
 
 const base = new Date(params.simulationDate)
 const { beginningOfYear, endOfYear } = useFinancialYear(base, 1, 4)

--- a/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
@@ -7,7 +7,7 @@
     <input
       class="form-field text-right"
       type="text"
-      :value="scheduledSocialInsuranceValue"
+      :value="scheduledSocialInsurance"
       @blur="handleChange"
       v-maska="{ mask: '#*' }"
       placeholder="500000"
@@ -33,7 +33,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { useGlobalStore } from '../../store/global'
 import { useFinancialYear } from '../../composables/use-financial-year'
@@ -46,11 +46,6 @@ const base = new Date(params.simulationDate)
 const { beginningOfYear, endOfYear } = useFinancialYear(base, 1, 4)
 const from = format(beginningOfYear, 'yyyy年M月d日')
 const to = format(endOfYear, 'yyyy年M月d日')
-
-const scheduledSocialInsuranceValue = computed({
-  get: () => scheduledSocialInsurance.value || params.scheduledSocialInsurance,
-  set: (value) => (scheduledSocialInsurance.value = value)
-})
 
 let {
   value: scheduledSocialInsurance,

--- a/app/javascript/src/components/simulation_form/SocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/SocialInsurance.vue
@@ -7,7 +7,7 @@
     <input
       class="form-field text-right"
       type="text"
-      :value="socialInsuranceValue"
+      :value="socialInsurance"
       @blur="handleChange"
       v-maska="{ mask: '#*' }"
       placeholder="500000"
@@ -21,7 +21,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import { useField } from 'vee-validate'
 import { format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
@@ -34,11 +34,6 @@ const base = new Date(params.simulationDate)
 const { lastBeginningOfYear, lastEndOfYear } = useFinancialYear(base, 1, 4)
 const from = format(lastBeginningOfYear, 'yyyy年M月d日')
 const to = format(lastEndOfYear, 'yyyy年M月d日')
-
-const socialInsuranceValue = computed({
-  get: () => socialInsurance.value || params.socialInsurance,
-  set: (value) => (socialInsurance.value = value)
-})
 
 let {
   value: socialInsurance,


### PR DESCRIPTION
storeとMountedを利用することで、初期値設定のために一時変数を設ける必要がなくなったため

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
