### PR TITLE
郵便番号から住所が取得できない場合にバリデーションが実行されるように修正

### DIFF
--- a/app/javascript/src/validation-schema.js
+++ b/app/javascript/src/validation-schema.js
@@ -53,7 +53,8 @@ export const useValidationSchema = (baseDate) => {
           message: '7桁の郵便番号を入力してください',
           excludeEmptyString: true
         })
-        .required('郵便番号は必須です')
+        .required('郵便番号は必須です'),
+      address: yup.string().required('該当する市区町村がありません')
     }),
     yup.object({
       salary: yup


### PR DESCRIPTION
changeイベントで郵便番号の検索とバリデーションを同時に実行したいが、
イベントの重複の関係かvee-validate側のhandleChangeと同時に実行できない

そのため、暫定的にblurとchangeのイベントを共存させている

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
