### PR TITLE
使用していない`font-bold`/`font-sans`の指定を削除

### DIFF
--- a/app/javascript/src/SimulationForm.vue
+++ b/app/javascript/src/SimulationForm.vue
@@ -23,7 +23,7 @@ const onSubmit = () => router.push('/simulations')
 
 <style scope>
 .form-label {
-  @apply font-bold text-4xl h-32;
+  @apply text-4xl h-32;
 }
 
 .form-field {
@@ -35,10 +35,10 @@ const onSubmit = () => router.push('/simulations')
 }
 
 .form-error {
-  @apply flex justify-center text-red-500 font-bold mt-2;
+  @apply flex justify-center text-red-500 mt-2;
 }
 
 .form-supplement {
-  @apply pl-4 text-4xl text-black font-bold;
+  @apply pl-4 text-4xl text-black;
 }
 </style>

--- a/app/javascript/src/SimulationResult.vue
+++ b/app/javascript/src/SimulationResult.vue
@@ -7,7 +7,7 @@
   <div v-else>
     <div class="max-w-screen-lg mx-auto pt-32 text-center">
       <div class="mb-6 mx-32">
-        <p class="text-3xl font-bold">
+        <p class="text-3xl">
           {{ formatDate(result.retirement_month) }}に退職して、{{
             formatDate(result.employment_month)
           }}に就職すると...
@@ -17,10 +17,10 @@
         <p>
           <span class="font-bold">約</span>
           <span class="mx-6">
-            <span class="text-8xl text-green-700 font-bold">{{
+            <span class="text-8xl text-green-700">{{
               formatAmount(result.grand_total)
             }}</span>
-            <span class="text-3xl text-green-700 font-bold ml-2">円</span>
+            <span class="text-3xl text-green-700 ml-2">円</span>
           </span>
           <span class="font-bold">かかります</span>
         </p>
@@ -47,13 +47,13 @@
       </div>
       <div class="flex flex-wrap justify-around mb-52 mx-64">
         <button
-          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg font-bold bg-green-700 text-white hover:bg-green-800 shadow-xl"
+          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg bg-green-700 text-white hover:bg-green-800 shadow-xl"
           @click="moveForm"
         >
           もういちど計算する
         </button>
         <button
-          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg font-bold bg-amber-400 text-white hover:bg-amber-500 shadow-xl"
+          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg bg-amber-400 text-white hover:bg-amber-500 shadow-xl"
           @click="scrollDetail"
         >
           詳細をみる
@@ -64,7 +64,7 @@
       <div
         class="max-w-screen-lg mx-auto px-12 py-16 bg-white rounded-3xl mb-16"
       >
-        <h2 class="text-center font-bold text-4xl mb-6">個人負担額の詳細</h2>
+        <h2 class="text-center text-4xl mb-6">個人負担額の詳細</h2>
         <div
           v-for="monthly_payment in result.monthly_payment"
           :key="monthly_payment.month"
@@ -98,7 +98,7 @@
       </div>
       <div class="flex justify-center">
         <button
-          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg font-bold bg-green-100 text-gray-500 hover:bg-green-200 shadow-xl"
+          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg bg-green-100 text-gray-500 hover:bg-green-200 shadow-xl"
           @click="scrollTop"
         >
           ページ上部へ

--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -2,11 +2,9 @@
   <form class="mt-24" @submit="onSubmit">
     <div class="flex">
       <h2>
-        <span class="text-6xl font-bold text-primary">{{ displayStep }}</span>
+        <span class="text-6xl text-primary">{{ displayStep }}</span>
         <span class="text-3xl font-semi-bold text-gray"> / </span>
-        <span class="text-4xl font-bold text-primary">{{
-          zeroPadStepCounter
-        }}</span>
+        <span class="text-4xl text-primary">{{ zeroPadStepCounter }}</span>
       </h2>
       <ProgressBar :top="raw" :bottom="stepCounter" />
     </div>

--- a/app/javascript/src/insurances.vue
+++ b/app/javascript/src/insurances.vue
@@ -3,7 +3,7 @@
     <div class="mx-auto">
       <div class="flex justify-between items-center">
         <div>
-          <h1 class="text-3xl py-4 font-sans font-bold">国民健康保険料一覧</h1>
+          <h1 class="text-3xl py-4">国民健康保険料一覧</h1>
         </div>
         <div>
           <a

--- a/app/javascript/src/pensions.vue
+++ b/app/javascript/src/pensions.vue
@@ -3,7 +3,7 @@
     <div class="mx-auto">
       <div class="flex justify-between items-center">
         <div>
-          <h1 class="text-3xl py-4 font-sans font-bold">国民年金保険料一覧</h1>
+          <h1 class="text-3xl py-4">国民年金保険料一覧</h1>
         </div>
         <div>
           <a

--- a/app/views/application/_errors.html.slim
+++ b/app/views/application/_errors.html.slim
@@ -1,6 +1,6 @@
 - if object.errors.any?
   .bg-red-100.border.border-red-400.text-red-700.px-4.py-3.rounded.mb-2
-    h3.font-bold.mb-2
+    h3.mb-2
       | 入力内容にエラーがありました
     ul.ml-4.text-sm
       - object.errors.full_messages.each do |msg|

--- a/app/views/insurances/_form.html.slim
+++ b/app/views/insurances/_form.html.slim
@@ -1,6 +1,6 @@
 = render 'errors', object: insurance_form
 = form_with model: insurance_form, html: { name: 'insurance' } do |f|
-  h3.leading-7.text-lg.font-bold
+  h3.leading-7.text-lg
     | 基本情報
   .flex.flex-col.mb-4
     = f.label :year, class: 'admin-form-label'
@@ -9,7 +9,7 @@
     = f.label :local_gov_code, class: 'admin-form-label'
     .w-full.rounded-md.border-2.border-boundaryBlack.focus:ring-1.focus:ring-primary.text-base.outline-none.py-1.px-3.leading-8.transition-colors.duration-200.ease-in-out
       = f.collection_select :local_gov_code, JpLocalGov.all, :code, ->(lg) { "#{lg.prefecture} #{lg.city}" }, include_blank: true
-    h3.leading-7.text-lg.font-bold.mt-8
+    h3.leading-7.text-lg.mt-8
       | 医療分
     .flex.flex-col.mb-4
       = f.label :medical_income_basis, class: 'admin-form-label'
@@ -36,7 +36,7 @@
       = f.number_field :medical_limit, class: 'admin-form-input'
       span.text-xs.text-gray.ml-1.mt-1
         | 0以上の数値を入力してください（単位：¥、デフォルト：0）
-    h3.leading-7.text-lg.font-bold.mt-8
+    h3.leading-7.text-lg.mt-8
       | 後期高齢者支援分
     .flex.flex-col.mb-4
       = f.label :elderly_income_basis, class: 'admin-form-label'
@@ -63,7 +63,7 @@
       = f.number_field :elderly_limit, class: 'admin-form-input'
       span.text-xs.text-gray.ml-1.mt-1
         | 0以上の数値を入力してください（単位：¥、デフォルト：0）
-    h3.leading-7.text-lg.font-bold.mt-8
+    h3.leading-7.text-lg.mt-8
       | 介護分
     .flex.flex-col.mb-4
       = f.label :care_income_basis, class: 'admin-form-label'
@@ -90,7 +90,7 @@
       = f.number_field :care_limit, class: 'admin-form-input'
       span.text-xs.text-gray.ml-1.mt-1
         | 0以上の数値を入力してください（単位：¥、デフォルト：0）
-    h3.leading-7.text-lg.font-bold.mt-8
+    h3.leading-7.text-lg.mt-8
       | 納付対象月
     span.text-xs.text-gray
       | 納付対象月をチェックしてください

--- a/app/views/insurances/edit.html.slim
+++ b/app/views/insurances/edit.html.slim
@@ -2,7 +2,7 @@
 
 .container.mx-auto.mb-8
   .mx-auto.px-2.max-w-2xl
-    h1.text-3xl.py-4.font-sans.font-bold
+    h1.text-3xl.py-4
       | 国民健康保険料編集
     .px-2
       = render 'form', insurance_form: @insurance_form

--- a/app/views/insurances/new.html.slim
+++ b/app/views/insurances/new.html.slim
@@ -2,7 +2,7 @@
 
 .container.mx-auto.mb-8
   .mx-auto.px-2.max-w-2xl
-    h1.text-3xl.py-4.font-sans.font-bold
+    h1.text-3xl.py-4
       | 国民健康保険料登録
     .px-2
       = render 'form', insurance_form: @insurance_form

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -30,7 +30,7 @@ html
     - if notice
       .w-full
         .p-24.bg-secondary.items-center.text-white.leading-none.flex.py-3
-          span.flex.rounded-full.bg-primary.uppercase.px-2.py-1.text-xs.font-bold.mr-3
+          span.flex.rounded-full.bg-primary.uppercase.px-2.py-1.text-xs.mr-3
             | INFO
           span.font-semibold.mr-2.text-left.text-sm.lex-auto
             = notice

--- a/app/views/pensions/edit.html.slim
+++ b/app/views/pensions/edit.html.slim
@@ -2,7 +2,7 @@
 
 .container.mx-auto.mb-8
   .mx-auto.px-2.max-w-2xl
-    h1.text-3xl.py-4.font-sans.font-bold
+    h1.text-3xl.py-4
       | 国民年金保険料編集
     .px-2
       = render 'form', pension: @pension

--- a/app/views/pensions/new.html.slim
+++ b/app/views/pensions/new.html.slim
@@ -2,7 +2,7 @@
 
 .container.mx-auto.mb-8
   .mx-auto.px-2.max-w-2xl
-    h1.text-3xl.py-4.font-sans.font-bold
+    h1.text-3xl.py-4
       | 国民年金保険料登録
     .px-2
       = render 'form', pension: @pension


### PR DESCRIPTION
フォントの切り替えによりあえて指定する必要がなくなったため

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
