### PR TITLE
バリデーションの実行タイミングをchangeイベントに変更

### DIFF
--- a/app/javascript/src/components/simulation_form/Age.vue
+++ b/app/javascript/src/components/simulation_form/Age.vue
@@ -5,7 +5,7 @@
       class="form-field text-right"
       type="text"
       :value="age"
-      @blur="handleChange"
+      @change="handleChange"
       placeholder="30"
     /><span class="form-supplement">歳</span>
     <p class="form-error">{{ error }}</p>

--- a/app/javascript/src/components/simulation_form/EmploymentMonth.vue
+++ b/app/javascript/src/components/simulation_form/EmploymentMonth.vue
@@ -6,7 +6,7 @@
       type="text"
       v-maska="{ mask: '####/##' }"
       :value="employmentMonth"
-      @blur="handleChange"
+      @change="handleChange"
       placeholder="2022/02"
     />
     <p class="form-tips">

--- a/app/javascript/src/components/simulation_form/RetirementMonth.vue
+++ b/app/javascript/src/components/simulation_form/RetirementMonth.vue
@@ -6,7 +6,7 @@
       type="text"
       v-maska="{ mask: '####/##' }"
       :value="retirementMonth"
-      @blur="handleChange"
+      @change="handleChange"
       placeholder="2022/02"
     />
     <p class="form-tips">

--- a/app/javascript/src/components/simulation_form/Salary.vue
+++ b/app/javascript/src/components/simulation_form/Salary.vue
@@ -8,7 +8,7 @@
       class="form-field text-right"
       type="text"
       :value="salary"
-      @blur="handleChange"
+      @change="handleChange"
       v-maska="{ mask: '#*' }"
       placeholder="500000"
     />

--- a/app/javascript/src/components/simulation_form/ScheduledSalary.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSalary.vue
@@ -8,7 +8,7 @@
       class="form-field text-right"
       type="text"
       :value="scheduledSalary"
-      @blur="handleChange"
+      @change="handleChange"
       v-maska="{ mask: '#*' }"
       placeholder="500000"
     />

--- a/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
@@ -8,7 +8,7 @@
       class="form-field text-right"
       type="text"
       :value="scheduledSocialInsurance"
-      @blur="handleChange"
+      @change="handleChange"
       v-maska="{ mask: '#*' }"
       placeholder="500000"
     />

--- a/app/javascript/src/components/simulation_form/SocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/SocialInsurance.vue
@@ -8,7 +8,7 @@
       class="form-field text-right"
       type="text"
       :value="socialInsurance"
-      @blur="handleChange"
+      @change="handleChange"
       v-maska="{ mask: '#*' }"
       placeholder="500000"
     />


### PR DESCRIPTION
値が未入力の段階でフォーカスが外れるときもバリデーションが走るのはUXとして微妙であるため

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
