### PR TITLE
納付対象月が正しく取得できないことによる国民健康保険料計算エラーを修正

### DIFF
--- a/app/models/insurance_form.rb
+++ b/app/models/insurance_form.rb
@@ -17,6 +17,7 @@ class InsuranceForm # rubocop:disable Metrics/ClassLength
   validates :local_gov_code, presence: true
   validate :local_gov_code_must_meet_jis_std
   validate :local_gov_code_and_year_must_be_uniqueness
+  validates_with MonthAnyoneValidator
 
   with_options numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100, allow_nil: true } do
     validates :medical_income_basis

--- a/app/models/simulation/insurance.rb
+++ b/app/models/simulation/insurance.rb
@@ -25,12 +25,12 @@ class Simulation::Insurance
 
   def monthly_insurance
     yearly_insurance.flat_map do |year, fee|
-      payment_target_months = Insurance.rate(year: year, local_gov_code: local_gov_code).payment_target_months
+      payment_target_months = build_payment_target_month(year)
       payment_terms = payment_terms_by_fiscal_year[year]
       number_of_payment_duty = months_between(from: payment_terms.first, to: payment_terms.first.end_of_financial_year).count
       total_fee = fee * number_of_payment_duty / PaymentTargetMonth::CALENDAR.count
-      target_months_in_range = payment_target_months.map(&:month).intersection(payment_terms.map(&:beginning_of_month))
-      remain_dues = payment_target_months.select { |month| month.month >= payment_terms.first }
+      target_months_in_range = payment_target_months.intersection(payment_terms.map(&:beginning_of_month))
+      remain_dues = payment_target_months.select { |month| month >= payment_terms.first }
       fees_by_month = LocalTaxLaw.calc_installments(total_fee, remain_dues, municipal_ordinance: true)
 
       payment_terms.map do |month|
@@ -47,6 +47,12 @@ class Simulation::Insurance
       result[year] = LocalTaxLaw.calc_determined_amount { calculate_medical(year, salary) + calculate_elderly(year, salary) + calculate_care(year, salary) }
     end
     result
+  end
+
+  def build_payment_target_month(year)
+    months = Insurance.rate(year: year, local_gov_code: local_gov_code).payment_target_months.map(&:month)
+    diff = year - months.first.financial_year
+    diff.zero? ?  months : months.map { |month| month.advance(years: diff) }
   end
 
   def fiscal_years

--- a/app/validators/month_anyone_validator.rb
+++ b/app/validators/month_anyone_validator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class MonthAnyoneValidator < ActiveModel::Validator
+  def validate(record)
+    months = PaymentTargetMonth::CALENDAR.each_value.map { |num| record.send("month#{num}") }
+    return if months.any?
+
+    record.errors.add(:payment_target_months, '納付対象月は最低1つチェックしてください')
+  end
+end

--- a/spec/models/insurance_form_spec.rb
+++ b/spec/models/insurance_form_spec.rb
@@ -199,6 +199,21 @@ RSpec.describe InsuranceForm, type: :model do
         it { is_expected.to be_empty }
       end
     end
+
+    describe 'payment_target_months' do
+      subject { insurance_form.errors[:payment_target_months] }
+      before { insurance_form.valid? }
+
+      context 'when payment_target_months are checked' do
+        let(:insurance_form) { build(:insurance_form, month1: true) }
+        it { is_expected.to be_empty }
+      end
+
+      context 'when payment_target_months are NOT checked' do
+        let(:insurance_form) { build(:insurance_form) }
+        it { is_expected.to include '納付対象月は最低1つチェックしてください' }
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/models/simulation/insurance_spec.rb
+++ b/spec/models/simulation/insurance_spec.rb
@@ -588,5 +588,58 @@ RSpec.describe Simulation::Insurance, type: :model do
         end
       end
     end
+
+    context 'when Insurance record DOES NOT exist for the target year' do
+      let!(:retirement_month) { Time.zone.parse('2021-04-01') }
+      let!(:employment_month) { Time.zone.parse('2023-03-01') }
+
+      it 'calculate with fallback record' do
+        create(
+          :insurance,
+          :with_payment_target_months,
+          months: [6, 7, 8, 9, 10, 11, 12, 1, 2, 3],
+          year: 2021,
+          local_gov_code: '131016',
+          medical_income_basis: 7.25,
+          medical_capita_basis: 0,
+          medical_household_basis: 37_300,
+          medical_limit: 630_000,
+          elderly_income_basis: 2.04,
+          elderly_capita_basis: 0,
+          elderly_household_basis: 11_000,
+          elderly_limit: 190_000,
+          care_income_basis: 1.21,
+          care_capita_basis: 0,
+          care_household_basis: 14_200,
+          care_limit: 170_000
+        )
+        expected = [
+          { month: Time.zone.parse('2021-04-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-05-01'), insurance: 0 },
+          { month: Time.zone.parse('2021-06-01'), insurance: 39_200 },
+          { month: Time.zone.parse('2021-07-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-08-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-09-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-10-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-11-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2021-12-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-01-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-02-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-03-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-04-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-05-01'), insurance: 0 },
+          { month: Time.zone.parse('2022-06-01'), insurance: 39_200 },
+          { month: Time.zone.parse('2022-07-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-08-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-09-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-10-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-11-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2022-12-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2023-01-01'), insurance: 39_100 },
+          { month: Time.zone.parse('2023-02-01'), insurance: 39_100 }
+        ]
+        expect(subject).to eq expected
+      end
+    end
   end
 end


### PR DESCRIPTION
## 目的

Closes: #147

## バグの原因

国民健康保険料は、総額を求め、その年度でまだ残っている納付対象月で割ることによって、各納付対象月ごとの金額を算出する。

この「まだ残っている納付対象月」が以下のケースで0と判断され、0割が発生しAPIが正常に動作していなかった。

1. 納付対象月がそもそも登録されていないケース
1. 該当都市の該当年度の国民健康保険料のレコードがなく、別年度（もしくは別年度かつ別都市）のレコードで計算するケース。該当年度に納付対象月がないと判断されてしまう

## やったこと
前述のバグの原因で述べた原因1, 2に対して、それぞれ以下の対応を追加

### 1. 納付対象月に最低1月以上のバリデーションを追加

現実の制度的にも国民健康保険料の納付対象月が存在しないケースはないため、またその前提で各種計算ロジックを作成しているためバリデーションを追加した

### 2. 国民健康保険料がフォールバックした場合にも正しく計算できるよう修正

アプリの仕様として、国民健康保険料の計算に使用するレコードは次のようにフォールバックする

1. 対象年度、対象市区町村の値でレコードを取得する
2. 対象市区町村のもっとも大きい年度のレコードを取得する
3. 対象市区町村の都道府県庁所在地の、対象年度のレコードを取得する
4. 対象市区町村の都道府県庁所在地の、もっとも大きい年度のレコードを取得する

このうち、2と4の方法でレコードを取得した場合に、取得された納付対象月の年度と、計算している年度が異なり、正しく計算できない。そのため、これらの場合には現在計算している年度に合わせて、取得したレコードの年度を読み替えるようにする。


---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
