### PR TITLE
住民税の会計年度の始まりを正しく取得できるように修正

### DIFF
--- a/app/models/simulation/residence.rb
+++ b/app/models/simulation/residence.rb
@@ -6,7 +6,7 @@ class Simulation::Residence
   using(Module.new do
     refine ActiveSupport::TimeWithZone do
       def beginning_of_residence_fy
-        beginning_of_financial_year.next_month.next_month
+        prev_month.prev_month.beginning_of_financial_year.next_month.next_month
       end
 
       def residence_financial_year

--- a/app/models/simulation/residence.rb
+++ b/app/models/simulation/residence.rb
@@ -2,18 +2,7 @@
 
 class Simulation::Residence
   include MonthIterable
-
-  using(Module.new do
-    refine ActiveSupport::TimeWithZone do
-      def beginning_of_residence_fy
-        prev_month.prev_month.beginning_of_financial_year.next_month.next_month
-      end
-
-      def residence_financial_year
-        prev_month.prev_month.financial_year
-      end
-    end
-  end)
+  using Simulation::Residence::FinancialYearStartWithJune
 
   BASIC_DEDUCTION = 430_000
   PREFECTURE_CAPITA_BASIS = 1_500

--- a/app/models/simulation/residence/financial_year_start_with_june.rb
+++ b/app/models/simulation/residence/financial_year_start_with_june.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Simulation::Residence::FinancialYearStartWithJune
+  # Refs: config/initializers/fiscali.rb
+  refine ActiveSupport::TimeWithZone do
+    def beginning_of_residence_fy
+      prev_month.prev_month.beginning_of_financial_year.next_month.next_month
+    end
+
+    def residence_financial_year
+      prev_month.prev_month.financial_year
+    end
+  end
+end

--- a/spec/models/simulation/residence/financial_year_start_with_june_spec.rb
+++ b/spec/models/simulation/residence/financial_year_start_with_june_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Simulation::Residence::FinancialYearStartWithJune', type: :model do
+  using Simulation::Residence::FinancialYearStartWithJune
+
+  describe '#beginning_of_residence_fy' do
+    subject { time.beginning_of_residence_fy }
+    let!(:time) { Time.zone.parse("2022-#{month}-01") }
+
+    context 'when month is January' do
+      let!(:month) { '1' }
+      it { is_expected.to eq Time.zone.parse('2021-06-01') }
+    end
+
+    context 'when month is March' do
+      let!(:month) { '3' }
+      it { is_expected.to eq Time.zone.parse('2021-06-01') }
+    end
+
+    context 'when month is April' do
+      let!(:month) { '4' }
+      it { is_expected.to eq Time.zone.parse('2021-06-01') }
+    end
+
+    context 'when month is May' do
+      let!(:month) { '5' }
+      it { is_expected.to eq Time.zone.parse('2021-06-01') }
+    end
+
+    context 'when month is June' do
+      let!(:month) { '6' }
+      it { is_expected.to eq Time.zone.parse('2022-06-01') }
+    end
+
+    context 'when month is December' do
+      let!(:month) { '12' }
+      it { is_expected.to eq Time.zone.parse('2022-06-01') }
+    end
+  end
+
+  describe '#residence_financial_year' do
+    subject { time.residence_financial_year }
+    let!(:time) { Time.zone.parse("2022-#{month}-01") }
+
+    context 'when month is January' do
+      let!(:month) { '1' }
+      it { is_expected.to eq 2021 }
+    end
+
+    context 'when month is March' do
+      let!(:month) { '3' }
+      it { is_expected.to eq 2021 }
+    end
+
+    context 'when month is April' do
+      let!(:month) { '4' }
+      it { is_expected.to eq 2021 }
+    end
+
+    context 'when month is May' do
+      let!(:month) { '5' }
+      it { is_expected.to eq 2021 }
+    end
+
+    context 'when month is June' do
+      let!(:month) { '6' }
+      it { is_expected.to eq 2022 }
+    end
+
+    context 'when month is December' do
+      let!(:month) { '12' }
+      it { is_expected.to eq 2022 }
+    end
+  end
+end

--- a/spec/models/simulation/residence_spec.rb
+++ b/spec/models/simulation/residence_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Simulation::Residence, type: :model do
       let!(:scheduled_social_insurance) { 500_000 }
       context '年度の途中で退職し、年度のおわりまで無職でいる場合' do
         context '現在日付の年度で退職し、その年度のおわりまで無職でいる場合' do
-          context '1-5月に退職する場合' do
+          context '1-3月に退職する場合' do
             let!(:retirement_month) { Time.zone.parse('2022-02-01') }
             let!(:employment_month) { Time.zone.parse('2022-06-01') }
 
@@ -31,6 +31,19 @@ RSpec.describe Simulation::Residence, type: :model do
                 { month: Time.zone.parse('2022-02-01'), residence: 80_000 },
                 { month: Time.zone.parse('2022-03-01'), residence: 0 },
                 { month: Time.zone.parse('2022-04-01'), residence: 0 },
+                { month: Time.zone.parse('2022-05-01'), residence: 0 }
+              ]
+              expect(subject).to eq expected
+            end
+          end
+
+          context '4-5月に退職する場合' do
+            let!(:retirement_month) { Time.zone.parse('2022-04-01') }
+            let!(:employment_month) { Time.zone.parse('2022-06-01') }
+
+            it '該当年度の退職月~5月分の特別徴収額が、退職月に一括請求されること' do
+              expected = [
+                { month: Time.zone.parse('2022-04-01'), residence: 40_000 },
                 { month: Time.zone.parse('2022-05-01'), residence: 0 }
               ]
               expect(subject).to eq expected


### PR DESCRIPTION
## 目的

Closes: #162

## バグの原因

変更前の処理では、対象の月に対して会計年度の始まりを求めた結果をシフトすることで住民税（6月始まり）の会計年度の始まりを求めていた。この場合、4月、5月については以下のように計算される。

| 対象 | 会計年度の始まり（実際） | 住民税の会計年度の始まり（実際） |
| --- | --- | --- |
| 2022年4月 | 2022年4月 | 2022年6月 |
| 2022年5月 | 2022年4月 | 2022年6月 |

しかし4、5月は6月始まりの会計年度だと前年度（この場合だと2021年度）であるため、結果として正しくない

## やったこと

- 6月始まり基準で会計年度を取得するように修正
- 会計年度取得のためにfiscaliの挙動を住民税限定でrefineしている。このrefinementの挙動のテストがなかったことがバグの原因の1つであるため、ファイルを分割してテストしやすくした。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
