### PR TITLE
社会保険料の「おまかせ入力」機能を実装

### DIFF
--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -1,5 +1,5 @@
 <template>
-  <form class="mt-24" @submit="onSubmit">
+  <form class="mt-20" @submit="onSubmit">
     <div class="flex">
       <h2>
         <span class="text-6xl text-primary">{{ displayStep }}</span>
@@ -8,7 +8,7 @@
       </h2>
       <ProgressBar :top="current" :bottom="steps" />
     </div>
-    <div class="px-24 m-24">
+    <div class="px-24 m-16">
       <slot />
     </div>
     <div class="flex justify-between">

--- a/app/javascript/src/components/simulation_form/InsuranceCompleteButton.vue
+++ b/app/javascript/src/components/simulation_form/InsuranceCompleteButton.vue
@@ -1,0 +1,42 @@
+<template>
+  <button
+    type="button"
+    class="border-0 w-48 p-3 focus:outline-none rounded-full text-sm bg-accent text-white hover:opacity-80 shadow-xl group relative cursor-pointer"
+    @click="completeInsurance"
+  >
+    <span
+      class="group-hover:opacity-100 group-hover:visible invisible opacity-0 absolute left-1/2 -translate-x-1/2 inline-block px-4 py-2 -bottom-12 whitespace-nowrap text-xs leading-tight bg-gray text-white rounded-xl ease-in duration-200 before:content-[''] before:absolute before:left-1/2 before:-top-3 before:-ml-2 before:border-8 before:border-solid before:border-transparent before:border-b-8 before:border-b-gray"
+      >{{ tooltipText }}</span
+    >
+    <i class="fas fa-robot mr-2"></i>おまかせで入力する
+  </button>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const emit = defineEmits(['completeInsurance'])
+const props = defineProps({
+  salary: {
+    type: Number,
+    required: true
+  }
+})
+
+const defaultText = '所得の値からざっくり計算します'
+const tooltipText = ref(defaultText)
+
+const completeInsurance = () => {
+  // 「ざっくり」補完なので、都道府県にかかわらず東京都の平均値である給与の15%で計算する
+  // 社会保険料は以下の要素から構成され、令和3年度における東京都/一般事業の場合の料率は次の通り
+  // 健康保険料（9.90%）、厚生年金保険料（19.3%）、介護保険料（1.73%）、雇用保険料（0.3%）、労災保険料（0.3%）
+  // また社会保険料は雇用者と折半となるため、その割合はおよそ15%になることを根拠として、この値での計算を行う
+  const socialInsuranceRate = 15 / 100
+  const insurance = Math.round((props.salary * socialInsuranceRate) / 100) * 100
+  emit('completeInsurance', insurance)
+  tooltipText.value = '値を設定しました！'
+  setTimeout(() => {
+    tooltipText.value = defaultText
+  }, 1000)
+}
+</script>

--- a/app/javascript/src/components/simulation_form/PreviousSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/PreviousSocialInsurance.vue
@@ -17,19 +17,26 @@
       >住民税の総額は、住民税決定通知書の「社会保険料」の値です
     </p>
     <p class="form-error">{{ error }}</p>
+    <InsuranceCompleteButton
+      :salary="previousSalary"
+      @completeInsurance="completeInsurance"
+      class="mt-2"
+    />
   </div>
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useField } from 'vee-validate'
 import { format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
 import { useFinancialYear } from '../../composables/use-financial-year'
+import InsuranceCompleteButton from './InsuranceCompleteButton'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
+const previousSalary = computed(() => Number(params.previousSalary))
 
 const base = new Date(params.simulationDate)
 const { beforeLastBeginningOfYear, beforeLastEndOfYear } = useFinancialYear(
@@ -39,6 +46,10 @@ const { beforeLastBeginningOfYear, beforeLastEndOfYear } = useFinancialYear(
 )
 const from = format(beforeLastBeginningOfYear, 'yyyy年M月d日')
 const to = format(beforeLastEndOfYear, 'yyyy年M月d日')
+
+const completeInsurance = (calculatedInsurance) => {
+  previousSocialInsurance.value = calculatedInsurance
+}
 
 let {
   value: previousSocialInsurance,

--- a/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
@@ -29,24 +29,35 @@
       </div>
     </div>
     <p class="form-error">{{ error }}</p>
+    <InsuranceCompleteButton
+      :salary="scheduledSalary"
+      @completeInsurance="completeInsurance"
+      class="mt-2"
+    />
   </div>
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useField } from 'vee-validate'
 import { useGlobalStore } from '../../store/global'
 import { useFinancialYear } from '../../composables/use-financial-year'
 import { format } from 'date-fns'
+import InsuranceCompleteButton from './InsuranceCompleteButton'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
+const scheduledSalary = computed(() => Number(params.scheduledSalary))
 
 const base = new Date(params.simulationDate)
 const { beginningOfYear, endOfYear } = useFinancialYear(base, 1, 4)
 const from = format(beginningOfYear, 'yyyy年M月d日')
 const to = format(endOfYear, 'yyyy年M月d日')
+
+const completeInsurance = (calculatedInsurance) => {
+  scheduledSocialInsurance.value = calculatedInsurance
+}
 
 let {
   value: scheduledSocialInsurance,

--- a/app/javascript/src/components/simulation_form/SocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/SocialInsurance.vue
@@ -17,24 +17,35 @@
       >住民税の総額は、住民税決定通知書の「社会保険料」の値です
     </p>
     <p class="form-error">{{ error }}</p>
+    <InsuranceCompleteButton
+      :salary="salary"
+      @completeInsurance="completeInsurance"
+      class="mt-2"
+    />
   </div>
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useField } from 'vee-validate'
 import { format } from 'date-fns'
 import { useGlobalStore } from '../../store/global'
 import { useFinancialYear } from '../../composables/use-financial-year'
+import InsuranceCompleteButton from './InsuranceCompleteButton'
 
 const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
+const salary = computed(() => Number(params.salary))
 
 const base = new Date(params.simulationDate)
 const { lastBeginningOfYear, lastEndOfYear } = useFinancialYear(base, 1, 4)
 const from = format(lastBeginningOfYear, 'yyyy年M月d日')
 const to = format(lastEndOfYear, 'yyyy年M月d日')
+
+const completeInsurance = (calculatedInsurance) => {
+  socialInsurance.value = calculatedInsurance
+}
 
 let {
   value: socialInsurance,


### PR DESCRIPTION
## 目的

住民税対応のために入力項目が増えることによるユーザーの入力負荷を削減する

## やったこと

- 「昨昨年度の社会保険料」「昨年度の社会保険料」「今年度の社会保険料」に社会保険料を所得から補完する「おまかせ入力」ボタンを追加
    - おまかせ入力を押すと、該当年度の所得の「15%」を自動設定する

## UIの変更

**「おまかせ入力」**

![CleanShot 2022-03-12 at 21 11 24](https://user-images.githubusercontent.com/61409641/158017488-142de6cb-848f-4fbe-9bc9-0930e11b6d3c.png)

**ツールチップ**

![CleanShot 2022-03-12 at 21 12 06](https://user-images.githubusercontent.com/61409641/158017496-f8d7474c-a646-4d2f-afe4-8a4671e90a14.gif)

**補完**

![CleanShot 2022-03-12 at 21 12 40](https://user-images.githubusercontent.com/61409641/158017510-ceaab806-b0c0-48ed-b379-7880b9209e02.gif)


## 申し送り事項

### 社会保険料の根拠

社会保険料は以下の要素から構成され、令和3年度における東京都/一般事業の場合の料率は次の通り
- 健康保険料（9.90%）
- 厚生年金保険料（19.3%）
- 介護保険料（1.73%）
- 雇用保険料（0.3%）
- 労災保険料（0.3%）

また社会保険料は雇用者と折半となるため、その割合はおよそ15%になることを根拠として、この値での計算を行う
※本来年齢による介護保険の適用有無を判断できるが、あくまで「ざっくり」として、機能をシンプルにしている

**参考**

- https://www.kyoukaikenpo.or.jp/g3/cat330/sb3150/h31/h31ryougakuhyou4gatukara/
- https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000108634.html
- https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/koyou_roudou/roudoukijun/rousai/rousaihoken06/rousai_hokenritsu_kaitei.html

### その他

ボタン追加に合わせて暫定的にフォーム全体のマージンを調整


---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
