### PR TITLE
翌々年度の会計年度を取得できるようにした

### DIFF
--- a/app/javascript/src/composables/__test__/useFinancialYear.spec.js
+++ b/app/javascript/src/composables/__test__/useFinancialYear.spec.js
@@ -59,6 +59,15 @@ describe('#nextBeginningOfYear', () => {
   })
 })
 
+describe('#afterNextBeginningOfYear', () => {
+  it('returns the after next year of beginningOfyear', () => {
+    const date = new Date('2022-03-14')
+    const { afterNextBeginningOfYear } = useFinancialYear(date, 4, 1)
+    const expected = new Date('2024-04-01')
+    expect(afterNextBeginningOfYear).toEqual(expected)
+  })
+})
+
 describe('#lastBeginningOfYear', () => {
   it('returns the last year of beginningOfyear', () => {
     const date = new Date('2022-03-14')

--- a/app/javascript/src/composables/useFinancialYear.js
+++ b/app/javascript/src/composables/useFinancialYear.js
@@ -17,6 +17,7 @@ export const useFinancialYear = (
       : subMonths(date, date_beginning_of_fiscal_year - 1).getFullYear()
   const beginningOfYear = new Date(year, beginning_of_fiscal_year - 1, 1)
   const nextBeginningOfYear = addYears(beginningOfYear, 1)
+  const afterNextBeginningOfYear = addYears(beginningOfYear, 2)
   const lastBeginningOfYear = subYears(beginningOfYear, 1)
   const beforeLastBeginningOfYear = subYears(beginningOfYear, 2)
   const endOfYear = lastDayOfMonth(addMonths(beginningOfYear, 11))
@@ -27,6 +28,7 @@ export const useFinancialYear = (
   return {
     beginningOfYear,
     nextBeginningOfYear,
+    afterNextBeginningOfYear,
     lastBeginningOfYear,
     beforeLastBeginningOfYear,
     endOfYear,


### PR DESCRIPTION
## 目的

バリデーションスキーマで使用するために、翌々年度の会計年度を取得できるようにする

## やったこと

`afterNextBeginningOfYear`で翌々年度を取得できるようにした

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
