### PR TITLE
useValidationSchemaのテストを追加

### DIFF
--- a/app/javascript/src/composables/__test__/useValidationSchema.spec.js
+++ b/app/javascript/src/composables/__test__/useValidationSchema.spec.js
@@ -1,0 +1,336 @@
+import { useValidationSchema } from '../useValidationSchema'
+
+describe('#validationSchema', () => {
+  const baseDate = new Date('2022-03-15')
+  const validationSchema = useValidationSchema(baseDate)
+
+  it('has all form validations', () => {
+    expect(validationSchema).toHaveProperty('RetirementMonth')
+    expect(validationSchema).toHaveProperty('EmploymentMonth')
+    expect(validationSchema).toHaveProperty('Age')
+    expect(validationSchema).toHaveProperty('PostalCode')
+    expect(validationSchema).toHaveProperty('PreviousSalary')
+    expect(validationSchema).toHaveProperty('Salary')
+    expect(validationSchema).toHaveProperty('ScheduledSalary')
+    expect(validationSchema).toHaveProperty('PreviousSocialInsurance')
+    expect(validationSchema).toHaveProperty('SocialInsurance')
+    expect(validationSchema).toHaveProperty('ScheduledSocialInsurance')
+  })
+
+  describe('RetirementMonth', () => {
+    const schema = validationSchema['RetirementMonth']
+
+    it('is invalid without retirementMonth', async () => {
+      const target = { retirementMonth: '' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '退職予定月は必須です'
+      )
+    })
+
+    it('is invalid with the month before the month of today', async () => {
+      const target = { retirementMonth: '2022/02' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '退職予定月には 2022/03 以降の月を指定してください'
+      )
+    })
+
+    it('is valid with the month of today', async () => {
+      const target = { retirementMonth: '2022/03' }
+      await expect(schema.validate(target)).resolves.toEqual({
+        retirementMonth: new Date('2022-03-01')
+      })
+    })
+
+    it('is invalid a month later than the beginning of the financial year two years later', async () => {
+      const target = { retirementMonth: '2023/05' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '退職予定月には 2023/04 以前の月を指定してください'
+      )
+    })
+
+    it('is valid with the beginning of the financial year two years later', async () => {
+      const target = { retirementMonth: '2023/04' }
+      await expect(schema.validate(target)).resolves.toEqual({
+        retirementMonth: new Date('2023-04-01')
+      })
+    })
+  })
+
+  describe('EmploymentMonth', () => {
+    const schema = validationSchema['EmploymentMonth']
+
+    it('is invalid without employmentMonth', async () => {
+      const target = { employmentMonth: '' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '転職予定月は必須です'
+      )
+    })
+
+    it('is invalid the month before retirementMonth', async () => {
+      const target = { retirementMonth: '2022/08', employmentMonth: '2022/06' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '転職予定月には、退職予定月以降の月を指定してください'
+      )
+    })
+
+    it('is invalid a month later than the beginning of the financial year two years later', async () => {
+      const target = { retirementMonth: '2022/08', employmentMonth: '2023/05' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '転職予定月には 2023/04 以前の月を指定してください'
+      )
+    })
+
+    it('is valid with the beginning of the financial year two years later', async () => {
+      const target = { retirementMonth: '2022/08', employmentMonth: '2023/04' }
+      await expect(schema.validate(target)).resolves.toEqual({
+        retirementMonth: new Date('2022-08-01'),
+        employmentMonth: new Date('2023-04-01')
+      })
+    })
+  })
+
+  describe('Age', () => {
+    const schema = validationSchema['Age']
+
+    it('is invalid without age', async () => {
+      const target = { age: '' }
+      await expect(schema.validate(target)).rejects.toThrow('年齢は必須です')
+    })
+
+    it('is invalid with negative number', async () => {
+      const target = { age: '-20' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '0以上の整数を入力してください'
+      )
+    })
+
+    it('is valid with zero', async () => {
+      const target = { age: '0' }
+      await expect(schema.validate(target)).resolves.toEqual({ age: 0 })
+    })
+
+    it('is invalid with decimal', async () => {
+      const target = { age: '21.2' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '整数で入力してください'
+      )
+    })
+  })
+
+  describe('PostalCode', () => {
+    const schema = validationSchema['PostalCode']
+
+    it('is invalid without postalCode', async () => {
+      const target = { postalCode: '', address: 'DUMMY' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '郵便番号は必須です'
+      )
+    })
+
+    it('is invalid without format: XXX-XXXX', async () => {
+      const target = { postalCode: '1000004', address: 'DUMMY' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '7桁の郵便番号を入力してください'
+      )
+    })
+
+    it('is invalid the address corresponding to the postcode cannot be found', async () => {
+      const target = { postalCode: '100-0004', address: '' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '該当する市区町村がありません'
+      )
+    })
+  })
+
+  describe('PreviousSalary', () => {
+    const schema = validationSchema['PreviousSalary']
+
+    it('is invalid without previousSalary', async () => {
+      const target = { previousSalary: '' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '昨昨年度の所得は必須です'
+      )
+    })
+
+    it('is invalid with negative number', async () => {
+      const target = { previousSalary: '-5000000' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '0以上の整数を入力してください'
+      )
+    })
+
+    it('is valid with zero', async () => {
+      const target = { previousSalary: '0' }
+      await expect(schema.validate(target)).resolves.toEqual({
+        previousSalary: 0
+      })
+    })
+
+    it('is invalid with decimal', async () => {
+      const target = { previousSalary: '5000000.1' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '整数で入力してください'
+      )
+    })
+  })
+
+  describe('PreviousSocialInsurance', () => {
+    const schema = validationSchema['PreviousSocialInsurance']
+
+    it('is invalid without previousSocialInsurance', async () => {
+      const target = { previousSocialInsurance: '' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '昨昨年度の社会保険料は必須です'
+      )
+    })
+
+    it('is invalid with negative number', async () => {
+      const target = { previousSocialInsurance: '-5000000' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '0以上の整数を入力してください'
+      )
+    })
+
+    it('is valid with zero', async () => {
+      const target = { previousSocialInsurance: '0' }
+      await expect(schema.validate(target)).resolves.toEqual({
+        previousSocialInsurance: 0
+      })
+    })
+
+    it('is invalid with decimal', async () => {
+      const target = { previousSocialInsurance: '5000000.1' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '整数で入力してください'
+      )
+    })
+  })
+
+  describe('Salary', () => {
+    const schema = validationSchema['Salary']
+
+    it('is invalid without salary', async () => {
+      const target = { salary: '' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '昨年度の所得は必須です'
+      )
+    })
+
+    it('is invalid with negative number', async () => {
+      const target = { salary: '-5000000' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '0以上の整数を入力してください'
+      )
+    })
+
+    it('is valid with zero', async () => {
+      const target = { salary: '0' }
+      await expect(schema.validate(target)).resolves.toEqual({
+        salary: 0
+      })
+    })
+
+    it('is invalid with decimal', async () => {
+      const target = { salary: '5000000.1' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '整数で入力してください'
+      )
+    })
+  })
+
+  describe('SocialInsurance', () => {
+    const schema = validationSchema['SocialInsurance']
+
+    it('is invalid without socialInsurance', async () => {
+      const target = { socialInsurance: '' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '昨年度の社会保険料は必須です'
+      )
+    })
+
+    it('is invalid with negative number', async () => {
+      const target = { socialInsurance: '-5000000' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '0以上の整数を入力してください'
+      )
+    })
+
+    it('is valid with zero', async () => {
+      const target = { socialInsurance: '0' }
+      await expect(schema.validate(target)).resolves.toEqual({
+        socialInsurance: 0
+      })
+    })
+
+    it('is invalid with decimal', async () => {
+      const target = { socialInsurance: '5000000.1' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '整数で入力してください'
+      )
+    })
+  })
+
+  describe('ScheduledSalary', () => {
+    const schema = validationSchema['ScheduledSalary']
+
+    it('is invalid without scheduledSalary', async () => {
+      const target = { scheduledSalary: '' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '今年度の所得は必須です'
+      )
+    })
+
+    it('is invalid with negative number', async () => {
+      const target = { scheduledSalary: '-5000000' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '0以上の整数を入力してください'
+      )
+    })
+
+    it('is valid with zero', async () => {
+      const target = { scheduledSalary: '0' }
+      await expect(schema.validate(target)).resolves.toEqual({
+        scheduledSalary: 0
+      })
+    })
+
+    it('is invalid with decimal', async () => {
+      const target = { scheduledSalary: '5000000.1' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '整数で入力してください'
+      )
+    })
+  })
+
+  describe('ScheduledSocialInsurance', () => {
+    const schema = validationSchema['ScheduledSocialInsurance']
+
+    it('is invalid without scheduledSocialInsurance', async () => {
+      const target = { scheduledSocialInsurance: '' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '今年度の社会保険料は必須です'
+      )
+    })
+
+    it('is invalid with negative number', async () => {
+      const target = { scheduledSocialInsurance: '-5000000' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '0以上の整数を入力してください'
+      )
+    })
+
+    it('is valid with zero', async () => {
+      const target = { scheduledSocialInsurance: '0' }
+      await expect(schema.validate(target)).resolves.toEqual({
+        scheduledSocialInsurance: 0
+      })
+    })
+
+    it('is invalid with decimal', async () => {
+      const target = { scheduledSocialInsurance: '5000000.1' }
+      await expect(schema.validate(target)).rejects.toThrow(
+        '整数で入力してください'
+      )
+    })
+  })
+})

--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -12,8 +12,11 @@ export const useValidationSchema = (baseDate) => {
     RetirementMonth: yup.object({
       retirementMonth: yup
         .date()
+        .nullable()
+        .transform((value, originalValue) =>
+          originalValue === '' ? null : value
+        )
         .required('退職予定月は必須です')
-        .typeError('無効な日付です。YYYY/MMの形式で入力してください。')
         .min(
           computableFrom,
           `退職予定月には ${computableFrom} 以降の月を指定してください`
@@ -22,13 +25,17 @@ export const useValidationSchema = (baseDate) => {
           computableTo,
           `退職予定月には ${computableTo} 以前の月を指定してください`
         )
+        .typeError('無効な日付です。YYYY/MMの形式で入力してください。')
     }),
     EmploymentMonth: yup.object({
       retirementMonth: yup.date(),
       employmentMonth: yup
         .date()
+        .nullable()
+        .transform((value, originalValue) =>
+          originalValue === '' ? null : value
+        )
         .required('転職予定月は必須です')
-        .typeError('無効な日付です。YYYY/MMの形式で入力してください。')
         .min(
           yup.ref('retirementMonth'),
           `転職予定月には、退職予定月以降の月を指定してください`
@@ -37,14 +44,16 @@ export const useValidationSchema = (baseDate) => {
           computableTo,
           `転職予定月には ${computableTo} 以前の月を指定してください`
         )
+        .typeError('無効な日付です。YYYY/MMの形式で入力してください。')
     }),
     Age: yup.object({
       age: yup
         .number()
+        .transform((value) => (isNaN(value) ? undefined : value))
         .required('年齢は必須です')
-        .typeError('無効な数値です。')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
+        .typeError('無効な数値です。')
     }),
     PostalCode: yup.object({
       postalCode: yup
@@ -59,50 +68,56 @@ export const useValidationSchema = (baseDate) => {
     PreviousSalary: yup.object({
       previousSalary: yup
         .number()
+        .transform((value) => (isNaN(value) ? undefined : value))
         .required('昨昨年度の所得は必須です')
-        .typeError('無効な数値です。')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
+        .typeError('無効な数値です。')
     }),
     PreviousSocialInsurance: yup.object({
       previousSocialInsurance: yup
         .number()
+        .transform((value) => (isNaN(value) ? undefined : value))
         .required('昨昨年度の社会保険料は必須です')
-        .typeError('無効な数値です。')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
+        .typeError('無効な数値です。')
     }),
     Salary: yup.object({
       salary: yup
         .number()
+        .transform((value) => (isNaN(value) ? undefined : value))
         .required('昨年度の所得は必須です')
-        .typeError('無効な数値です。')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
+        .typeError('無効な数値です。')
     }),
     SocialInsurance: yup.object({
       socialInsurance: yup
         .number()
+        .transform((value) => (isNaN(value) ? undefined : value))
         .required('昨年度の社会保険料は必須です')
-        .typeError('無効な数値です。')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
+        .typeError('無効な数値です。')
     }),
     ScheduledSalary: yup.object({
       scheduledSalary: yup
         .number()
+        .transform((value) => (isNaN(value) ? undefined : value))
         .required('今年度の所得は必須です')
-        .typeError('無効な数値です。')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
+        .typeError('無効な数値です。')
     }),
     ScheduledSocialInsurance: yup.object({
       scheduledSocialInsurance: yup
         .number()
+        .transform((value) => (isNaN(value) ? undefined : value))
         .required('今年度の社会保険料は必須です')
-        .typeError('無効な数値です。')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
+        .typeError('無効な数値です。')
     })
   }
 

--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -31,7 +31,7 @@ export const useValidationSchema = (baseDate) => {
         .typeError('無効な日付です。YYYY/MMの形式で入力してください。')
         .min(
           yup.ref('retirementMonth'),
-          `転職予定月には、退職月以降の月を指定してください`
+          `転職予定月には、退職予定月以降の月を指定してください`
         )
         .max(
           computableTo,

--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -99,7 +99,7 @@ export const useValidationSchema = (baseDate) => {
     ScheduledSocialInsurance: yup.object({
       scheduledSocialInsurance: yup
         .number()
-        .required('今年度の所得は必須です')
+        .required('今年度の社会保険料は必須です')
         .typeError('無効な数値です。')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')


### PR DESCRIPTION
## 目的

不足していた`useValidationSchema`のテストを追加する

## やったこと

- `useValidationSchema`のテストを追加
- テスト追加により発覚した以下のバグを修正
    - 今年度の社会保険料の必須チェックのメッセージで「所得」と表示している箇所を「社会保険料」に修正
    - 転職予定月のチェックのメッセージで「退職月」と表示している箇所を「退職予定月」に修正
    - 空欄だった場合に、yup側でキャストエラーになっていた箇所を、必須エラーとなるよう修正

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
