### PR TITLE
useValidationSchemaをリファクタリング

### DIFF
--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -1,4 +1,4 @@
-import * as yup from 'yup'
+import { object, string, number, date, ref } from 'yup'
 import { getYear, subMonths, addYears, format } from 'date-fns'
 
 export const useValidationSchema = (baseDate) => {
@@ -9,16 +9,14 @@ export const useValidationSchema = (baseDate) => {
   )
 
   const numberPresence = (columnName) => {
-    return yup
-      .number()
+    return number()
       .transform((value) => (isNaN(value) ? undefined : value))
       .required(`${columnName}は必須です`)
       .typeError('無効な数値です。')
   }
 
   const datePresence = (columnName) => {
-    return yup
-      .date()
+    return date()
       .nullable()
       .transform((value, originalValue) =>
         originalValue === '' ? null : value
@@ -26,7 +24,7 @@ export const useValidationSchema = (baseDate) => {
       .required(`${columnName}は必須です`)
   }
 
-  const RetirementMonth = yup.object({
+  const RetirementMonth = object({
     retirementMonth: datePresence('退職予定月')
       .min(
         computableFrom,
@@ -38,11 +36,11 @@ export const useValidationSchema = (baseDate) => {
       )
   })
 
-  const EmploymentMonth = yup.object({
-    retirementMonth: yup.date(),
+  const EmploymentMonth = object({
+    retirementMonth: date(),
     employmentMonth: datePresence('転職予定月')
       .min(
-        yup.ref('retirementMonth'),
+        ref('retirementMonth'),
         `転職予定月には、退職予定月以降の月を指定してください`
       )
       .max(
@@ -51,54 +49,53 @@ export const useValidationSchema = (baseDate) => {
       )
   })
 
-  const Age = yup.object({
+  const Age = object({
     age: numberPresence('年齢')
       .min(0, '0以上の整数を入力してください')
       .integer('整数で入力してください')
   })
 
-  const PostalCode = yup.object({
-    postalCode: yup
-      .string()
+  const PostalCode = object({
+    postalCode: string()
       .matches(/^[0-9]{3}-[0-9]{4}$/, {
         message: '7桁の郵便番号を入力してください',
         excludeEmptyString: true
       })
       .required('郵便番号は必須です'),
-    address: yup.string().required('該当する市区町村がありません')
+    address: string().required('該当する市区町村がありません')
   })
 
-  const PreviousSalary = yup.object({
+  const PreviousSalary = object({
     previousSalary: numberPresence('昨昨年度の所得')
       .min(0, '0以上の整数を入力してください')
       .integer('整数で入力してください')
   })
 
-  const PreviousSocialInsurance = yup.object({
+  const PreviousSocialInsurance = object({
     previousSocialInsurance: numberPresence('昨昨年度の社会保険料')
       .min(0, '0以上の整数を入力してください')
       .integer('整数で入力してください')
   })
 
-  const Salary = yup.object({
+  const Salary = object({
     salary: numberPresence('昨年度の所得')
       .min(0, '0以上の整数を入力してください')
       .integer('整数で入力してください')
   })
 
-  const SocialInsurance = yup.object({
+  const SocialInsurance = object({
     socialInsurance: numberPresence('昨年度の社会保険料')
       .min(0, '0以上の整数を入力してください')
       .integer('整数で入力してください')
   })
 
-  const ScheduledSalary = yup.object({
+  const ScheduledSalary = object({
     scheduledSalary: numberPresence('今年度の所得')
       .min(0, '0以上の整数を入力してください')
       .integer('整数で入力してください')
   })
 
-  const ScheduledSocialInsurance = yup.object({
+  const ScheduledSocialInsurance = object({
     scheduledSocialInsurance: numberPresence('今年度の社会保険料')
       .min(0, '0以上の整数を入力してください')
       .integer('整数で入力してください')

--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -4,8 +4,8 @@ import { format } from 'date-fns'
 
 export const useValidationSchema = (baseDate) => {
   const { afterNextBeginningOfYear } = useFinancialYear(baseDate, 4)
-  const computableFrom = format(baseDate, 'yyyy/MM')
-  const computableTo = format(afterNextBeginningOfYear, 'yyyy/MM')
+  const from = format(baseDate, 'yyyy/MM')
+  const to = format(afterNextBeginningOfYear, 'yyyy/MM')
 
   const numberPresence = (columnName) => {
     return number()
@@ -17,22 +17,14 @@ export const useValidationSchema = (baseDate) => {
   const datePresence = (columnName) => {
     return date()
       .nullable()
-      .transform((value, originalValue) =>
-        originalValue === '' ? null : value
-      )
+      .transform((value, original) => (original === '' ? null : value))
       .required(`${columnName}は必須です`)
   }
 
   const RetirementMonth = object({
     retirementMonth: datePresence('退職予定月')
-      .min(
-        computableFrom,
-        `退職予定月には ${computableFrom} 以降の月を指定してください`
-      )
-      .max(
-        computableTo,
-        `退職予定月には ${computableTo} 以前の月を指定してください`
-      )
+      .min(from, `退職予定月には ${from} 以降の月を指定してください`)
+      .max(to, `退職予定月には ${to} 以前の月を指定してください`)
   })
 
   const EmploymentMonth = object({
@@ -42,10 +34,7 @@ export const useValidationSchema = (baseDate) => {
         ref('retirementMonth'),
         `転職予定月には、退職予定月以降の月を指定してください`
       )
-      .max(
-        computableTo,
-        `転職予定月には ${computableTo} 以前の月を指定してください`
-      )
+      .max(to, `転職予定月には ${to} 以前の月を指定してください`)
   })
 
   const Age = object({

--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -1,12 +1,11 @@
 import { object, string, number, date, ref } from 'yup'
-import { getYear, subMonths, addYears, format } from 'date-fns'
+import { useFinancialYear } from './useFinancialYear'
+import { format } from 'date-fns'
 
 export const useValidationSchema = (baseDate) => {
+  const { afterNextBeginningOfYear } = useFinancialYear(baseDate, 4)
   const computableFrom = format(baseDate, 'yyyy/MM')
-  const computableTo = format(
-    new Date(getYear(addYears(subMonths(baseDate, 3), 2)), 3, 1),
-    'yyyy/MM'
-  )
+  const computableTo = format(afterNextBeginningOfYear, 'yyyy/MM')
 
   const numberPresence = (columnName) => {
     return number()

--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -26,75 +26,95 @@ export const useValidationSchema = (baseDate) => {
       .required(`${columnName}は必須です`)
   }
 
+  const RetirementMonth = yup.object({
+    retirementMonth: datePresence('退職予定月')
+      .min(
+        computableFrom,
+        `退職予定月には ${computableFrom} 以降の月を指定してください`
+      )
+      .max(
+        computableTo,
+        `退職予定月には ${computableTo} 以前の月を指定してください`
+      )
+  })
+
+  const EmploymentMonth = yup.object({
+    retirementMonth: yup.date(),
+    employmentMonth: datePresence('転職予定月')
+      .min(
+        yup.ref('retirementMonth'),
+        `転職予定月には、退職予定月以降の月を指定してください`
+      )
+      .max(
+        computableTo,
+        `転職予定月には ${computableTo} 以前の月を指定してください`
+      )
+  })
+
+  const Age = yup.object({
+    age: numberPresence('年齢')
+      .min(0, '0以上の整数を入力してください')
+      .integer('整数で入力してください')
+  })
+
+  const PostalCode = yup.object({
+    postalCode: yup
+      .string()
+      .matches(/^[0-9]{3}-[0-9]{4}$/, {
+        message: '7桁の郵便番号を入力してください',
+        excludeEmptyString: true
+      })
+      .required('郵便番号は必須です'),
+    address: yup.string().required('該当する市区町村がありません')
+  })
+
+  const PreviousSalary = yup.object({
+    previousSalary: numberPresence('昨昨年度の所得')
+      .min(0, '0以上の整数を入力してください')
+      .integer('整数で入力してください')
+  })
+
+  const PreviousSocialInsurance = yup.object({
+    previousSocialInsurance: numberPresence('昨昨年度の社会保険料')
+      .min(0, '0以上の整数を入力してください')
+      .integer('整数で入力してください')
+  })
+
+  const Salary = yup.object({
+    salary: numberPresence('昨年度の所得')
+      .min(0, '0以上の整数を入力してください')
+      .integer('整数で入力してください')
+  })
+
+  const SocialInsurance = yup.object({
+    socialInsurance: numberPresence('昨年度の社会保険料')
+      .min(0, '0以上の整数を入力してください')
+      .integer('整数で入力してください')
+  })
+
+  const ScheduledSalary = yup.object({
+    scheduledSalary: numberPresence('今年度の所得')
+      .min(0, '0以上の整数を入力してください')
+      .integer('整数で入力してください')
+  })
+
+  const ScheduledSocialInsurance = yup.object({
+    scheduledSocialInsurance: numberPresence('今年度の社会保険料')
+      .min(0, '0以上の整数を入力してください')
+      .integer('整数で入力してください')
+  })
+
   const validationSchema = {
-    RetirementMonth: yup.object({
-      retirementMonth: datePresence('退職予定月')
-        .min(
-          computableFrom,
-          `退職予定月には ${computableFrom} 以降の月を指定してください`
-        )
-        .max(
-          computableTo,
-          `退職予定月には ${computableTo} 以前の月を指定してください`
-        )
-    }),
-    EmploymentMonth: yup.object({
-      retirementMonth: yup.date(),
-      employmentMonth: datePresence('転職予定月')
-        .min(
-          yup.ref('retirementMonth'),
-          `転職予定月には、退職予定月以降の月を指定してください`
-        )
-        .max(
-          computableTo,
-          `転職予定月には ${computableTo} 以前の月を指定してください`
-        )
-    }),
-    Age: yup.object({
-      age: numberPresence('年齢')
-        .min(0, '0以上の整数を入力してください')
-        .integer('整数で入力してください')
-    }),
-    PostalCode: yup.object({
-      postalCode: yup
-        .string()
-        .matches(/^[0-9]{3}-[0-9]{4}$/, {
-          message: '7桁の郵便番号を入力してください',
-          excludeEmptyString: true
-        })
-        .required('郵便番号は必須です'),
-      address: yup.string().required('該当する市区町村がありません')
-    }),
-    PreviousSalary: yup.object({
-      previousSalary: numberPresence('昨昨年度の所得')
-        .min(0, '0以上の整数を入力してください')
-        .integer('整数で入力してください')
-    }),
-    PreviousSocialInsurance: yup.object({
-      previousSocialInsurance: numberPresence('昨昨年度の社会保険料')
-        .min(0, '0以上の整数を入力してください')
-        .integer('整数で入力してください')
-    }),
-    Salary: yup.object({
-      salary: numberPresence('昨年度の所得')
-        .min(0, '0以上の整数を入力してください')
-        .integer('整数で入力してください')
-    }),
-    SocialInsurance: yup.object({
-      socialInsurance: numberPresence('昨年度の社会保険料')
-        .min(0, '0以上の整数を入力してください')
-        .integer('整数で入力してください')
-    }),
-    ScheduledSalary: yup.object({
-      scheduledSalary: numberPresence('今年度の所得')
-        .min(0, '0以上の整数を入力してください')
-        .integer('整数で入力してください')
-    }),
-    ScheduledSocialInsurance: yup.object({
-      scheduledSocialInsurance: numberPresence('今年度の社会保険料')
-        .min(0, '0以上の整数を入力してください')
-        .integer('整数で入力してください')
-    })
+    RetirementMonth,
+    EmploymentMonth,
+    Age,
+    PostalCode,
+    PreviousSalary,
+    PreviousSocialInsurance,
+    Salary,
+    SocialInsurance,
+    ScheduledSalary,
+    ScheduledSocialInsurance
   }
 
   return validationSchema

--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -8,15 +8,27 @@ export const useValidationSchema = (baseDate) => {
     'yyyy/MM'
   )
 
+  const numberPresence = (columnName) => {
+    return yup
+      .number()
+      .transform((value) => (isNaN(value) ? undefined : value))
+      .required(`${columnName}は必須です`)
+      .typeError('無効な数値です。')
+  }
+
+  const datePresence = (columnName) => {
+    return yup
+      .date()
+      .nullable()
+      .transform((value, originalValue) =>
+        originalValue === '' ? null : value
+      )
+      .required(`${columnName}は必須です`)
+  }
+
   const validationSchema = {
     RetirementMonth: yup.object({
-      retirementMonth: yup
-        .date()
-        .nullable()
-        .transform((value, originalValue) =>
-          originalValue === '' ? null : value
-        )
-        .required('退職予定月は必須です')
+      retirementMonth: datePresence('退職予定月')
         .min(
           computableFrom,
           `退職予定月には ${computableFrom} 以降の月を指定してください`
@@ -25,17 +37,10 @@ export const useValidationSchema = (baseDate) => {
           computableTo,
           `退職予定月には ${computableTo} 以前の月を指定してください`
         )
-        .typeError('無効な日付です。YYYY/MMの形式で入力してください。')
     }),
     EmploymentMonth: yup.object({
       retirementMonth: yup.date(),
-      employmentMonth: yup
-        .date()
-        .nullable()
-        .transform((value, originalValue) =>
-          originalValue === '' ? null : value
-        )
-        .required('転職予定月は必須です')
+      employmentMonth: datePresence('転職予定月')
         .min(
           yup.ref('retirementMonth'),
           `転職予定月には、退職予定月以降の月を指定してください`
@@ -44,16 +49,11 @@ export const useValidationSchema = (baseDate) => {
           computableTo,
           `転職予定月には ${computableTo} 以前の月を指定してください`
         )
-        .typeError('無効な日付です。YYYY/MMの形式で入力してください。')
     }),
     Age: yup.object({
-      age: yup
-        .number()
-        .transform((value) => (isNaN(value) ? undefined : value))
-        .required('年齢は必須です')
+      age: numberPresence('年齢')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
-        .typeError('無効な数値です。')
     }),
     PostalCode: yup.object({
       postalCode: yup
@@ -66,58 +66,34 @@ export const useValidationSchema = (baseDate) => {
       address: yup.string().required('該当する市区町村がありません')
     }),
     PreviousSalary: yup.object({
-      previousSalary: yup
-        .number()
-        .transform((value) => (isNaN(value) ? undefined : value))
-        .required('昨昨年度の所得は必須です')
+      previousSalary: numberPresence('昨昨年度の所得')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
-        .typeError('無効な数値です。')
     }),
     PreviousSocialInsurance: yup.object({
-      previousSocialInsurance: yup
-        .number()
-        .transform((value) => (isNaN(value) ? undefined : value))
-        .required('昨昨年度の社会保険料は必須です')
+      previousSocialInsurance: numberPresence('昨昨年度の社会保険料')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
-        .typeError('無効な数値です。')
     }),
     Salary: yup.object({
-      salary: yup
-        .number()
-        .transform((value) => (isNaN(value) ? undefined : value))
-        .required('昨年度の所得は必須です')
+      salary: numberPresence('昨年度の所得')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
-        .typeError('無効な数値です。')
     }),
     SocialInsurance: yup.object({
-      socialInsurance: yup
-        .number()
-        .transform((value) => (isNaN(value) ? undefined : value))
-        .required('昨年度の社会保険料は必須です')
+      socialInsurance: numberPresence('昨年度の社会保険料')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
-        .typeError('無効な数値です。')
     }),
     ScheduledSalary: yup.object({
-      scheduledSalary: yup
-        .number()
-        .transform((value) => (isNaN(value) ? undefined : value))
-        .required('今年度の所得は必須です')
+      scheduledSalary: numberPresence('今年度の所得')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
-        .typeError('無効な数値です。')
     }),
     ScheduledSocialInsurance: yup.object({
-      scheduledSocialInsurance: yup
-        .number()
-        .transform((value) => (isNaN(value) ? undefined : value))
-        .required('今年度の社会保険料は必須です')
+      scheduledSocialInsurance: numberPresence('今年度の社会保険料')
         .min(0, '0以上の整数を入力してください')
         .integer('整数で入力してください')
-        .typeError('無効な数値です。')
     })
   }
 


### PR DESCRIPTION
## やったこと

 - 数値、日付の必須チェックをメソッドに抽出
 - 変数`validationSchema`はチェック対象のみを保持するオブジェクトに修正
     - validationSchemaにチェック対象とチェック内容の双方を含んでいると、全体としてどのカラムにチェックがかかっているかがわかりづらい。そのためvalidationSchemaが保持しているチェック内容を、各メソッドに抽出した
 - ビルドサイズ削減のため、yupのimport対象を最小限に変更
 - バリデーションに必要な翌々年度を別モジュールから取得するように変更
     - 会計年度に関する責務をuseFinancialYearに集約するため。また愚直な日付の加減算は結果がわかりづらく、privateゆえにテストもできないため、テスタブルな別モジュールに処理を移譲した
 - 変更後の命名でも意味がとれるものは、スタイルを優先して短い名前に変更した

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
