### PR TITLE
ユーザーが使用する画面のボタンのレイアウトを一括で修正

### DIFF
--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -11,17 +11,13 @@
     <div class="px-24 m-16">
       <slot />
     </div>
-    <div class="flex justify-between">
-      <button
-        class="button text-gray bg-secondary hover:bg-primary hover:text-white rounded-full"
-        v-if="prev"
-        type="button"
-        @click="goToPrev"
-      >
+    <div class="flex justify-evenly">
+      <button class="prev-button" v-if="prev" type="button" @click="goToPrev">
         まえの質問へ
       </button>
       <button
-        class="ml-auto button text-white bg-primary hover:bg-green-900"
+        class="ml-auto"
+        :class="next ? 'next-button' : 'submit-button'"
         type="submit"
       >
         {{ nextStep }}
@@ -82,7 +78,15 @@ const goToPrev = () => {
 </script>
 
 <style scope>
-.button {
-  @apply border-0 py-4 px-8 focus:outline-none rounded-full text-xl;
+.next-button {
+  @apply flex justify-between items-center bg-primary text-white rounded-full text-lg w-52 px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray;
+}
+
+.submit-button {
+  @apply flex justify-evenly items-center bg-accent text-white rounded-full text-lg w-52 px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-accent after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray;
+}
+
+.prev-button {
+  @apply flex justify-between items-center bg-secondary text-gray rounded-full text-lg w-52 px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-secondary before:content-[''] before:w-3 before:h-3 before:rotate-45 before:border-solid before:border-gray before:border-b-4 before:border-l-4 before:hover:border-gray;
 }
 </style>

--- a/app/javascript/src/components/Home.vue
+++ b/app/javascript/src/components/Home.vue
@@ -14,7 +14,7 @@
       </div>
       <div class="flex justify-center">
         <button
-          class="border-0 w-40 md:w-56 p-4 md:p-6 focus:outline-none rounded-full text-sm md:text-lg bg-primary text-white hover:bg-accent shadow-xl"
+          class="flex justify-between items-center bg-primary text-white rounded-full text-lg w-60 px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray"
           @click="moveForm"
         >
           いますぐ計算する

--- a/app/javascript/src/components/SimulationResult.vue
+++ b/app/javascript/src/components/SimulationResult.vue
@@ -57,15 +57,15 @@
           </p>
         </div>
       </div>
-      <div class="flex flex-wrap justify-around mb-52 mx-64">
+      <div class="flex flex-wrap justify-around mb-52 mx-52">
         <button
-          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg bg-primary text-white hover:opacity-70 shadow-xl"
+          class="text-lg w-64 flex justify-between items-center bg-primary text-white rounded-full px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary before:content-[''] before:w-3 before:h-3 before:rotate-45 before:border-solid before:border-white before:border-b-4 before:border-l-4 before:hover:border-gray"
           @click="moveForm"
         >
           もういちど計算する
         </button>
         <button
-          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg bg-accent text-white hover:opacity-70 shadow-xl"
+          class="text-lg w-60 flex justify-evenly items-center bg-accent text-white rounded-full px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-accent after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray"
           @click="scrollDetail"
         >
           詳細をみる
@@ -112,7 +112,7 @@
       </div>
       <div class="flex justify-center">
         <button
-          class="border-0 w-56 py-6 px-6 focus:outline-none rounded-full text-lg bg-primary text-white hover:opacity-70 shadow-xl"
+          class="w-52 flex justify-evenly items-center bg-primary text-white rounded-full px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-l-4 after:border-t-4 after:hover:border-gray"
           @click="scrollTop"
         >
           ページ上部へ


### PR DESCRIPTION
Closes: #181

## UIの変更

### ホーム画面

![CleanShot 2022-03-14 at 21 58 45](https://user-images.githubusercontent.com/61409641/158176840-9f7e8fea-2714-4339-9421-f908743c77bc.gif)

### フォーム

![CleanShot 2022-03-14 at 21 59 54](https://user-images.githubusercontent.com/61409641/158176992-53a1711d-e626-40b9-a8f2-9d5f50935056.gif)

### 結果画面

![CleanShot 2022-03-14 at 22 00 23](https://user-images.githubusercontent.com/61409641/158177051-96038c57-5508-488a-be1f-0ddaae562a5c.gif)

![CleanShot 2022-03-14 at 22 00 50](https://user-images.githubusercontent.com/61409641/158177092-64db57b3-18cd-459c-ab0b-f702b13e7bb4.gif)

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
