### PR TITLE
fix(router): SPA側のRouterの設定を値が取得できた場合に変更

### DIFF
--- a/app/javascript/src/router/router.js
+++ b/app/javascript/src/router/router.js
@@ -97,16 +97,16 @@ router.afterEach((to) => {
     : DEFAULT_TITLE
   const content = to.meta.description || DEFAULT_DESCRIPTION
 
+  const ogTitle = document.querySelector("meta[property='og:title']")
+  const description = document.querySelector("meta[name='description']")
+  const ogDescription = document.querySelector(
+    "meta[property='og:description']"
+  )
+
   document.title = title
-  document
-    .querySelector("meta[property='og:title']")
-    .setAttribute('content', title)
-  document
-    .querySelector("meta[name='description']")
-    .setAttribute('content', content)
-  document
-    .querySelector("meta[property='og:description']")
-    .setAttribute('content', content)
+  if (ogTitle) ogTitle.setAttribute('content', title)
+  if (description) description.setAttribute('content', content)
+  if (ogDescription) description.setAttribute('content', content)
 })
 
 export default router


### PR DESCRIPTION
## 目的

このアプリのViewはVueとRailsが分かれており、metaが記載されているheadはRails側に書かれている。
テストなどVue単体で動く箇所でWarnがでるため、条件分岐を追加してRails側が取れない時には警告やエラーを抑制する。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
