### PR TITLE
build(vue): production環境でのみdata-test-id属性を除外する設定

### DIFF
--- a/config/webpack/loaders/vue.js
+++ b/config/webpack/loaders/vue.js
@@ -1,7 +1,31 @@
+function removeAttr(astEl, name) {
+  const { attrsList, attrsMap } = astEl
+  if (attrsMap[name]) {
+    delete attrsMap[name]
+    const index = attrsList.findIndex((x) => x.name === name)
+    attrsList.splice(index, 1)
+  }
+  return astEl
+}
+
+function removeTestAttr(astEl) {
+  removeAttr(astEl, 'data-test-id')
+  removeAttr(astEl, ':data-test-id')
+  return astEl
+}
+
+const compileModules =
+  process.env.NODE_ENV === 'production'
+    ? [{ preTransformNode: removeTestAttr }]
+    : []
+
 module.exports = {
   test: /\.vue$/,
   loader: 'vue-loader',
   options: {
-    reactivityTransform: true
+    reactivityTransform: true,
+    compilerOptions: {
+      modules: compileModules
+    }
   }
 }


### PR DESCRIPTION
## 目的

tailwindCSSを利用している関係で、各要素がCSSで識別しづらくテストが実行しづらい。
そのためテスト用のデータ属性`data-test-id`を付与したいが、productionでは不要であるため、コンパイル時に除去する設定を追加した。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
