### PR TITLE
コンポーネントテストを追加

### DIFF
--- a/app/javascript/src/__test__/InsuranceCompleteButton.spec.js
+++ b/app/javascript/src/__test__/InsuranceCompleteButton.spec.js
@@ -1,0 +1,49 @@
+import { shallowMount } from '@vue/test-utils'
+import InsuranceCompleteButton from '../components/simulation_form/InsuranceCompleteButton'
+
+describe('InsuranceCompleteButton', () => {
+  describe('emit', () => {
+    describe('when InsuranceCompleteButton is clicked', () => {
+      describe('when props:salary is 0', () => {
+        it('fires completeInsurance event with insurance: 0', async () => {
+          const wrapper = shallowMount(InsuranceCompleteButton, {
+            props: {
+              salary: 0
+            }
+          })
+
+          await wrapper
+            .get(`[data-test-id="completeInsuranceButton"]`)
+            .trigger('click')
+
+          const emit = wrapper.emitted()
+
+          expect(emit).toHaveProperty('completeInsurance')
+
+          expect(emit['completeInsurance'][0]).toEqual([0])
+        })
+      })
+
+      describe('when props:salary is NOT 0', () => {
+        it('fires completeInsurance event with insurance which is 15% of the salary rounded down to the nearest 100 yen', async () => {
+          const wrapper = shallowMount(InsuranceCompleteButton, {
+            props: {
+              salary: 4578921
+            }
+          })
+
+          await wrapper
+            .get(`[data-test-id="completeInsuranceButton"]`)
+            .trigger('click')
+
+          const emit = wrapper.emitted()
+
+          expect(emit).toHaveProperty('completeInsurance')
+
+          // 4578921 * 15% = 686831.15
+          expect(emit['completeInsurance'][0]).toEqual([686800])
+        })
+      })
+    })
+  })
+})

--- a/app/javascript/src/__test__/ProgressBar.spec.js
+++ b/app/javascript/src/__test__/ProgressBar.spec.js
@@ -1,0 +1,60 @@
+import { shallowMount } from '@vue/test-utils'
+import ProgressBar from '../components/ProgressBar'
+
+describe('ProgressBar', () => {
+  describe('props', () => {
+    describe('when top is 0', () => {
+      it('should show only steps bar', () => {
+        const wrapper = shallowMount(ProgressBar, {
+          props: {
+            top: 0,
+            bottom: 10
+          }
+        })
+
+        expect(wrapper.find(`[data-test-id="Progress"]`).exists()).toBe(false)
+        expect(wrapper.find(`[data-test-id="Steps"]`).exists()).toBe(true)
+      })
+    })
+
+    describe('when top is NOT 0 and top is smaller than bottom', () => {
+      const wrapper = shallowMount(ProgressBar, {
+        props: {
+          top: 3,
+          bottom: 10
+        }
+      })
+
+      it('should show only progress bar', () => {
+        expect(wrapper.find(`[data-test-id="Progress"]`).exists()).toBe(true)
+        expect(wrapper.find(`[data-test-id="Steps"]`).exists()).toBe(false)
+      })
+
+      it('should calculate progress by top/bottom', () => {
+        expect(
+          wrapper.get(`[data-test-id="Progress"]`).attributes().style
+        ).toContain('width: 30%') // 3 / 10 * 100 = 30%
+      })
+    })
+
+    describe('when top is bottom', () => {
+      const wrapper = shallowMount(ProgressBar, {
+        props: {
+          top: 10,
+          bottom: 10
+        }
+      })
+
+      it('should show only progress bar', () => {
+        expect(wrapper.find(`[data-test-id="Progress"]`).exists()).toBe(true)
+        expect(wrapper.find(`[data-test-id="Steps"]`).exists()).toBe(false)
+      })
+
+      it('should calculate progress by top/bottom, and its result is 100%', () => {
+        expect(
+          wrapper.get(`[data-test-id="Progress"]`).attributes().style
+        ).toContain('width: 100%') // 10 / 10 * 100 = 100%
+      })
+    })
+  })
+})

--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -6,7 +6,7 @@
         <span class="text-3xl font-semi-bold text-gray"> / </span>
         <span class="text-4xl text-primary">{{ zeroPadStepCounter }}</span>
       </h2>
-      <ProgressBar :top="current" :bottom="steps" />
+      <ProgressBar :top="current" :bottom="steps - 1" />
     </div>
     <div class="px-24 m-16">
       <slot />

--- a/app/javascript/src/components/ProgressBar.vue
+++ b/app/javascript/src/components/ProgressBar.vue
@@ -28,7 +28,5 @@ const props = defineProps({
   }
 })
 
-const progress = computed(() =>
-  Math.ceil((props.top / (props.bottom - 1)) * 100)
-)
+const progress = computed(() => Math.ceil((props.top / props.bottom) * 100))
 </script>

--- a/app/javascript/src/components/ProgressBar.vue
+++ b/app/javascript/src/components/ProgressBar.vue
@@ -5,15 +5,13 @@
         v-if="progress"
         class="bg-primary text-xs font-medium text-primary text-center p-0.5 leading-none rounded-full"
         :style="{ width: progress + '%' }"
-      >
-        1
-      </div>
+        data-test-id="Progress"
+      ></div>
       <div
         v-else
-        class="bg-secondary text-xs font-medium text-secondary text-left py-0.5 pl-8 leading-none rounded-full"
-      >
-        0
-      </div>
+        class="bg-secondary text-xs font-medium text-secondary text-left py-0.5 pl-8 leading-none rounded-full h-3"
+        data-test-id="Steps"
+      ></div>
     </div>
   </div>
 </template>

--- a/app/javascript/src/components/ProgressBar.vue
+++ b/app/javascript/src/components/ProgressBar.vue
@@ -3,7 +3,7 @@
     <div class="w-full bg-secondary rounded-full">
       <div
         v-if="progress"
-        class="bg-primary text-xs font-medium text-primary text-center p-0.5 leading-none rounded-full"
+        class="bg-primary text-xs font-medium text-primary text-center p-0.5 leading-none rounded-full h-3"
         :style="{ width: progress + '%' }"
         data-test-id="Progress"
       ></div>

--- a/app/javascript/src/components/simulation_form/InsuranceCompleteButton.vue
+++ b/app/javascript/src/components/simulation_form/InsuranceCompleteButton.vue
@@ -2,6 +2,7 @@
   <button
     type="button"
     class="border-0 w-48 p-3 focus:outline-none rounded-full text-sm bg-accent text-white hover:opacity-80 shadow-xl group relative cursor-pointer"
+    data-test-id="completeInsuranceButton"
     @click="completeInsurance"
   >
     <span


### PR DESCRIPTION
## 目的

Closes: #192

## やったこと

- コンポーネントテストを追加
    - ProgressBarのテストを追加
    - InsuranceCompleteButtonのテストを追加
    - props / emitを利用している、振る舞いが変化するコンポーネントのみにテストを追加した（その他のコンポーネントはインテグレーションテスト or システムテストで保証する）
- テスト追加に伴って気がついた軽微な点を修正
    - ProgressBarの表示の高さを数字（`0`、`1`）で制御していた部分をheightで修正
    - ProgressBarでおこなっている進捗の計算で、受け取る値が「配列の長さであること」を前提としていたが、より汎用的になるように単純に「現在のステップ数 / すべてのステップ数」となるように変更した。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
