### PR TITLE
管理系画面をCompositionAPIに合わせて書き換える

### DIFF
--- a/app/javascript/src/components/Insurances.vue
+++ b/app/javascript/src/components/Insurances.vue
@@ -1,181 +1,175 @@
 <template>
   <div class="container mx-auto">
-    <div class="mx-auto">
-      <div class="flex justify-between items-center">
-        <div>
-          <h1 class="text-3xl py-4">国民健康保険料一覧</h1>
-        </div>
-        <div>
-          <a
-            href="/admin/insurances/new"
-            class="inline-block text-white bg-primary border-0 py-2 px-4 focus:outline-none hover:bg-green-900 rounded-full text-sm"
-            >新規登録</a
-          >
-        </div>
-      </div>
-      <LoadingAnimation v-if="!insurances.length" />
-      <div
-        v-else
-        class="overflow-x-auto bg-white rounded-md shadow overflow-y-auto relative mb-4"
+    <header class="flex justify-between items-center">
+      <h1 class="text-3xl py-4">国民健康保険料一覧</h1>
+      <a
+        href="/admin/insurances/new"
+        class="inline-block text-white bg-primary border-0 py-2 px-4 focus:outline-none hover:bg-green-900 rounded-full text-sm"
+        >新規登録</a
       >
-        <table class="table-auto w-full whitespace-no-wrap bg-white relative">
-          <thead class="bg-boundaryBlack text-xs sticky top-0">
-            <tr>
-              <th class="admin-table-header">編集</th>
-              <th class="admin-table-header">削除</th>
-              <th class="admin-table-header">年度</th>
-              <th class="admin-table-header">都道府県</th>
-              <th class="admin-table-header">市区町村</th>
-              <th class="admin-table-header">都道府県庁所在地</th>
-              <th class="admin-table-header">所得割（医療分）</th>
-              <th class="admin-table-header">資産割（医療分）</th>
-              <th class="admin-table-header">均等割（医療分）</th>
-              <th class="admin-table-header">平等割（医療分）</th>
-              <th class="admin-table-header">限度額（医療分）</th>
-              <th class="admin-table-header">所得割（後期高齢者支援分）</th>
-              <th class="admin-table-header">資産割（後期高齢者支援分）</th>
-              <th class="admin-table-header">均等割（後期高齢者支援分）</th>
-              <th class="admin-table-header">平等割（後期高齢者支援分）</th>
-              <th class="admin-table-header">限度額（後期高齢者支援分）</th>
-              <th class="admin-table-header">所得割（介護分）</th>
-              <th class="admin-table-header">資産割（介護分）</th>
-              <th class="admin-table-header">均等割（介護分）</th>
-              <th class="admin-table-header">平等割（介護分）</th>
-              <th class="admin-table-header">限度額（介護分）</th>
-              <th class="admin-table-header">1月</th>
-              <th class="admin-table-header">2月</th>
-              <th class="admin-table-header">3月</th>
-              <th class="admin-table-header">4月</th>
-              <th class="admin-table-header">5月</th>
-              <th class="admin-table-header">6月</th>
-              <th class="admin-table-header">7月</th>
-              <th class="admin-table-header">8月</th>
-              <th class="admin-table-header">9月</th>
-              <th class="admin-table-header">10月</th>
-              <th class="admin-table-header">11月</th>
-              <th class="admin-table-header">12月</th>
-            </tr>
-          </thead>
+    </header>
+    <LoadingAnimation v-if="!insurances.length" />
+    <div
+      v-else
+      class="overflow-x-auto bg-white rounded-md shadow overflow-y-auto relative mb-4"
+    >
+      <table class="table-auto w-full whitespace-no-wrap bg-white relative">
+        <thead class="bg-boundaryBlack text-xs sticky top-0">
+          <tr>
+            <th class="admin-table-header">編集</th>
+            <th class="admin-table-header">削除</th>
+            <th class="admin-table-header">年度</th>
+            <th class="admin-table-header">都道府県</th>
+            <th class="admin-table-header">市区町村</th>
+            <th class="admin-table-header">都道府県庁所在地</th>
+            <th class="admin-table-header">所得割（医療分）</th>
+            <th class="admin-table-header">資産割（医療分）</th>
+            <th class="admin-table-header">均等割（医療分）</th>
+            <th class="admin-table-header">平等割（医療分）</th>
+            <th class="admin-table-header">限度額（医療分）</th>
+            <th class="admin-table-header">所得割（後期高齢者支援分）</th>
+            <th class="admin-table-header">資産割（後期高齢者支援分）</th>
+            <th class="admin-table-header">均等割（後期高齢者支援分）</th>
+            <th class="admin-table-header">平等割（後期高齢者支援分）</th>
+            <th class="admin-table-header">限度額（後期高齢者支援分）</th>
+            <th class="admin-table-header">所得割（介護分）</th>
+            <th class="admin-table-header">資産割（介護分）</th>
+            <th class="admin-table-header">均等割（介護分）</th>
+            <th class="admin-table-header">平等割（介護分）</th>
+            <th class="admin-table-header">限度額（介護分）</th>
+            <th class="admin-table-header">1月</th>
+            <th class="admin-table-header">2月</th>
+            <th class="admin-table-header">3月</th>
+            <th class="admin-table-header">4月</th>
+            <th class="admin-table-header">5月</th>
+            <th class="admin-table-header">6月</th>
+            <th class="admin-table-header">7月</th>
+            <th class="admin-table-header">8月</th>
+            <th class="admin-table-header">9月</th>
+            <th class="admin-table-header">10月</th>
+            <th class="admin-table-header">11月</th>
+            <th class="admin-table-header">12月</th>
+          </tr>
+        </thead>
 
-          <tbody class="text-xs">
-            <tr v-for="insurance in insurances" :key="insurance.id">
-              <td class="admin-table-data-center">
-                <a
-                  :href="insurance.edit_insurance_path"
-                  title="国民健康保険料編集"
-                  ><i class="fas fa-edit"></i>
-                </a>
-              </td>
-              <td class="admin-table-data-center">
-                <button @click="deleteInsurance(insurance.id)">
-                  <i class="fas fa-trash"></i>
-                </button>
-              </td>
-              <td class="admin-table-data-center">{{ insurance.year }}</td>
-              <td class="admin-table-data-center">
-                {{ insurance.prefecture }}
-              </td>
-              <td class="admin-table-data-center whitespace-nowrap">
-                {{ insurance.city }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.prefecture_capital ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatPercent(insurance.medical_income_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatPercent(insurance.medical_asset_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatYen(insurance.medical_capita_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatYen(insurance.medical_household_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatYen(insurance.medical_limit) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatPercent(insurance.elderly_income_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatPercent(insurance.elderly_asset_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatYen(insurance.elderly_capita_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatYen(insurance.elderly_household_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatYen(insurance.elderly_limit) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatPercent(insurance.care_income_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatPercent(insurance.care_asset_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatYen(insurance.care_capita_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatYen(insurance.care_household_basis) }}
-              </td>
-              <td class="admin-table-data-right">
-                {{ formatYen(insurance.care_limit) }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.january ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.february ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.march ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.april ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.may ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.june ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.july ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.august ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.september ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.october ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.november ? '○' : '-' }}
-              </td>
-              <td class="admin-table-data-center">
-                {{ insurance.december ? '○' : '-' }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div class="flex justify-center py-4">
-        <v-pagination
-          v-model="currentPage"
-          :pages="totalPages"
-          :range-size="1"
-          active-color="#117766"
-          @update:modelValue="switchPage"
-        />
-      </div>
+        <tbody class="text-xs">
+          <tr v-for="insurance in insurances" :key="insurance.id">
+            <td class="admin-table-data-center">
+              <a
+                :href="insurance.edit_insurance_path"
+                title="国民健康保険料編集"
+                ><i class="fas fa-edit"></i>
+              </a>
+            </td>
+            <td class="admin-table-data-center">
+              <button @click="deleteInsurance(insurance.id)">
+                <i class="fas fa-trash"></i>
+              </button>
+            </td>
+            <td class="admin-table-data-center">{{ insurance.year }}</td>
+            <td class="admin-table-data-center">
+              {{ insurance.prefecture }}
+            </td>
+            <td class="admin-table-data-center whitespace-nowrap">
+              {{ insurance.city }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.prefecture_capital ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatPercent(insurance.medical_income_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatPercent(insurance.medical_asset_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatYen(insurance.medical_capita_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatYen(insurance.medical_household_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatYen(insurance.medical_limit) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatPercent(insurance.elderly_income_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatPercent(insurance.elderly_asset_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatYen(insurance.elderly_capita_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatYen(insurance.elderly_household_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatYen(insurance.elderly_limit) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatPercent(insurance.care_income_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatPercent(insurance.care_asset_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatYen(insurance.care_capita_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatYen(insurance.care_household_basis) }}
+            </td>
+            <td class="admin-table-data-right">
+              {{ formatYen(insurance.care_limit) }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.january ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.february ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.march ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.april ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.may ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.june ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.july ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.august ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.september ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.october ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.november ? '○' : '-' }}
+            </td>
+            <td class="admin-table-data-center">
+              {{ insurance.december ? '○' : '-' }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
+    <nav class="flex justify-center py-4">
+      <v-pagination
+        v-model="currentPage"
+        :pages="totalPages"
+        :range-size="1"
+        active-color="#117766"
+        @update:modelValue="switchPage"
+      />
+    </nav>
   </div>
 </template>
 

--- a/app/javascript/src/components/Insurances.vue
+++ b/app/javascript/src/components/Insurances.vue
@@ -92,13 +92,13 @@
                 {{ formatPercent(insurance.medical_asset_basis) }}
               </td>
               <td class="admin-table-data-right">
-                {{ formatNumber(insurance.medical_capita_basis) }}
+                {{ formatYen(insurance.medical_capita_basis) }}
               </td>
               <td class="admin-table-data-right">
-                {{ formatNumber(insurance.medical_household_basis) }}
+                {{ formatYen(insurance.medical_household_basis) }}
               </td>
               <td class="admin-table-data-right">
-                {{ formatNumber(insurance.medical_limit) }}
+                {{ formatYen(insurance.medical_limit) }}
               </td>
               <td class="admin-table-data-right">
                 {{ formatPercent(insurance.elderly_income_basis) }}
@@ -107,13 +107,13 @@
                 {{ formatPercent(insurance.elderly_asset_basis) }}
               </td>
               <td class="admin-table-data-right">
-                {{ formatNumber(insurance.elderly_capita_basis) }}
+                {{ formatYen(insurance.elderly_capita_basis) }}
               </td>
               <td class="admin-table-data-right">
-                {{ formatNumber(insurance.elderly_household_basis) }}
+                {{ formatYen(insurance.elderly_household_basis) }}
               </td>
               <td class="admin-table-data-right">
-                {{ formatNumber(insurance.elderly_limit) }}
+                {{ formatYen(insurance.elderly_limit) }}
               </td>
               <td class="admin-table-data-right">
                 {{ formatPercent(insurance.care_income_basis) }}
@@ -122,13 +122,13 @@
                 {{ formatPercent(insurance.care_asset_basis) }}
               </td>
               <td class="admin-table-data-right">
-                {{ formatNumber(insurance.care_capita_basis) }}
+                {{ formatYen(insurance.care_capita_basis) }}
               </td>
               <td class="admin-table-data-right">
-                {{ formatNumber(insurance.care_household_basis) }}
+                {{ formatYen(insurance.care_household_basis) }}
               </td>
               <td class="admin-table-data-right">
-                {{ formatNumber(insurance.care_limit) }}
+                {{ formatYen(insurance.care_limit) }}
               </td>
               <td class="admin-table-data-center">
                 {{ insurance.january ? '○' : '-' }}
@@ -187,7 +187,10 @@
 import { computed, ref } from 'vue'
 import VPagination from '@hennge/vue3-pagination'
 import '@hennge/vue3-pagination/dist/vue3-pagination.css'
+import { useFormat } from '../composables/useFormat'
 import Swal from 'sweetalert2'
+
+const { formatYen, formatPercent } = useFormat()
 
 const pageParam = () => {
   const url = new URL(location.href)
@@ -263,22 +266,6 @@ const switchPage = (pageNum) => {
   currentPage.value = pageNum
   history.pushState(null, null, newUrl.value)
   getInsurances()
-}
-
-// e.g. 30000 → ¥30,000
-const formatNumber = (number) => {
-  return new Intl.NumberFormat('ja', {
-    style: 'currency',
-    currency: 'JPY',
-    currencyDisplay: 'symbol'
-  }).format(number)
-}
-
-// e.g. 7.1 → 7.10%
-const formatPercent = (decimal) => {
-  return `${new Intl.NumberFormat('ja', {
-    minimumFractionDigits: 2
-  }).format(decimal)}%`
 }
 
 getInsurances()

--- a/app/javascript/src/components/Insurances.vue
+++ b/app/javascript/src/components/Insurances.vue
@@ -177,14 +177,15 @@
 import { onMounted, ref } from 'vue'
 import VPagination from '@hennge/vue3-pagination'
 import '@hennge/vue3-pagination/dist/vue3-pagination.css'
-import Swal from 'sweetalert2'
 import LoadingAnimation from './LoadingAnimation'
 import { useFormat } from '../composables/useFormat'
 import { useInsurances } from '../composables/useInsurances'
+import { useToast } from '../composables/useToast'
 
 const { formatYen, formatPercent } = useFormat()
 const { insurances, totalPages, getInsurances, deleteInsurance } =
   useInsurances()
+const { toast } = useToast()
 
 const pageParam = () => {
   const url = new URL(location.href)
@@ -206,17 +207,6 @@ const switchPage = (pageNum) => {
   currentPage.value = pageNum
   history.pushState(null, null, newUrl)
   getInsurances(newParams)
-}
-
-const toast = (title) => {
-  Swal.fire({
-    title: title,
-    toast: true,
-    position: 'top-end',
-    showConfirmButton: false,
-    timer: 3000,
-    timerProgressBar: true
-  })
 }
 
 const destroy = async (insuranceId) => {

--- a/app/javascript/src/components/Insurances.vue
+++ b/app/javascript/src/components/Insurances.vue
@@ -13,11 +13,7 @@
           >
         </div>
       </div>
-      <div v-if="!insurances.length" class="flex justify-center my-64">
-        <div class="animate-ping h-2 w-2 bg-primary rounded-full"></div>
-        <div class="animate-ping h-2 w-2 bg-primary rounded-full mx-8"></div>
-        <div class="animate-ping h-2 w-2 bg-primary rounded-full"></div>
-      </div>
+      <LoadingAnimation v-if="!insurances.length" />
       <div
         v-else
         class="overflow-x-auto bg-white rounded-md shadow overflow-y-auto relative mb-4"
@@ -189,6 +185,7 @@ import VPagination from '@hennge/vue3-pagination'
 import '@hennge/vue3-pagination/dist/vue3-pagination.css'
 import { useFormat } from '../composables/useFormat'
 import Swal from 'sweetalert2'
+import LoadingAnimation from './LoadingAnimation'
 
 const { formatYen, formatPercent } = useFormat()
 

--- a/app/javascript/src/components/LoadingAnimation.vue
+++ b/app/javascript/src/components/LoadingAnimation.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="flex justify-center my-64">
+    <div class="animate-ping h-2 w-2 bg-primary rounded-full"></div>
+    <div class="animate-ping h-2 w-2 bg-primary rounded-full mx-8"></div>
+    <div class="animate-ping h-2 w-2 bg-primary rounded-full"></div>
+  </div>
+</template>

--- a/app/javascript/src/components/Pensions.vue
+++ b/app/javascript/src/components/Pensions.vue
@@ -65,13 +65,14 @@
 import { onMounted, ref } from 'vue'
 import VPagination from '@hennge/vue3-pagination'
 import '@hennge/vue3-pagination/dist/vue3-pagination.css'
-import Swal from 'sweetalert2'
 import LoadingAnimation from './LoadingAnimation'
 import { useFormat } from '../composables/useFormat'
 import { usePensions } from '../composables/usePensions'
+import { useToast } from '../composables/useToast'
 
 const { formatYen } = useFormat()
 const { pensions, totalPages, getPensions, deletePension } = usePensions()
+const { toast } = useToast()
 
 const pageParam = () => {
   const url = new URL(location.href)
@@ -88,17 +89,6 @@ const newParams = $computed(() => {
 })
 
 const newUrl = $computed(() => `${location.pathname}?${newParams}`)
-
-const toast = (title) => {
-  Swal.fire({
-    title: title,
-    toast: true,
-    position: 'top-end',
-    showConfirmButton: false,
-    timer: 3000,
-    timerProgressBar: true
-  })
-}
 
 const destroy = async (pensionId) => {
   const result = confirm('本当にこのレコードを削除しますか')

--- a/app/javascript/src/components/Pensions.vue
+++ b/app/javascript/src/components/Pensions.vue
@@ -50,7 +50,7 @@
                 {{ pension.year }}
               </td>
               <td class="admin-table-data-center">
-                {{ formatNumber(pension.contribution) }}
+                {{ formatYen(pension.contribution) }}
               </td>
             </tr>
           </tbody>
@@ -71,9 +71,12 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import { useFormat } from '../composables/useFormat'
 import VPagination from '@hennge/vue3-pagination'
 import '@hennge/vue3-pagination/dist/vue3-pagination.css'
 import Swal from 'sweetalert2'
+
+const { formatYen } = useFormat()
 
 const pageParam = () => {
   const url = new URL(location.href)
@@ -149,15 +152,6 @@ const switchPage = (pageNum) => {
   currentPage.value = pageNum
   history.pushState(null, null, newUrl.value)
   getPensions()
-}
-
-// e.g. 30000 → ¥30,000
-const formatNumber = (number) => {
-  return new Intl.NumberFormat('ja', {
-    style: 'currency',
-    currency: 'JPY',
-    currencyDisplay: 'symbol'
-  }).format(number)
 }
 
 getPensions()

--- a/app/javascript/src/components/Pensions.vue
+++ b/app/javascript/src/components/Pensions.vue
@@ -13,11 +13,7 @@
           >
         </div>
       </div>
-      <div v-if="!pensions.length" class="flex justify-center my-64">
-        <div class="animate-ping h-2 w-2 bg-green-800 rounded-full"></div>
-        <div class="animate-ping h-2 w-2 bg-green-800 rounded-full mx-8"></div>
-        <div class="animate-ping h-2 w-2 bg-green-800 rounded-full"></div>
-      </div>
+      <LoadingAnimation v-if="!pensions.length" />
       <div
         v-else
         class="overflow-x-auto bg-white rounded-md shadow overflow-y-auto relative mb-4"
@@ -75,6 +71,7 @@ import { useFormat } from '../composables/useFormat'
 import VPagination from '@hennge/vue3-pagination'
 import '@hennge/vue3-pagination/dist/vue3-pagination.css'
 import Swal from 'sweetalert2'
+import LoadingAnimation from './LoadingAnimation'
 
 const { formatYen } = useFormat()
 

--- a/app/javascript/src/components/Pensions.vue
+++ b/app/javascript/src/components/Pensions.vue
@@ -1,18 +1,14 @@
 <template>
   <div class="container mx-auto">
     <div class="mx-auto">
-      <div class="flex justify-between items-center">
-        <div>
-          <h1 class="text-3xl py-4">国民年金保険料一覧</h1>
-        </div>
-        <div>
-          <a
-            href="/admin/pensions/new"
-            class="inline-block text-white bg-primary border-0 py-2 px-4 focus:outline-none hover:bg-green-900 rounded-full text-sm"
-            >新規登録</a
-          >
-        </div>
-      </div>
+      <header class="flex justify-between items-center">
+        <h1 class="text-3xl py-4">国民年金保険料一覧</h1>
+        <a
+          href="/admin/pensions/new"
+          class="inline-block text-white bg-primary border-0 py-2 px-4 focus:outline-none hover:bg-green-900 rounded-full text-sm"
+          >新規登録</a
+        >
+      </header>
       <LoadingAnimation v-if="!pensions.length" />
       <div
         v-else
@@ -52,7 +48,7 @@
           </tbody>
         </table>
       </div>
-      <div class="flex justify-center py-4">
+      <nav class="flex justify-center py-4">
         <v-pagination
           v-model="currentPage"
           :pages="totalPages"
@@ -60,7 +56,7 @@
           active-color="#117766"
           @update:modelValue="switchPage"
         />
-      </div>
+      </nav>
     </div>
   </div>
 </template>

--- a/app/javascript/src/components/SimulationResult.vue
+++ b/app/javascript/src/components/SimulationResult.vue
@@ -1,9 +1,5 @@
 <template>
-  <div v-if="loading" class="flex justify-center my-64">
-    <div class="animate-ping h-2 w-2 bg-primary rounded-full"></div>
-    <div class="animate-ping h-2 w-2 bg-primary rounded-full mx-8"></div>
-    <div class="animate-ping h-2 w-2 bg-primary rounded-full"></div>
-  </div>
+  <LoadingAnimation v-if="loading" />
   <div v-else>
     <div class="max-w-screen-lg mx-auto pt-32 text-center">
       <div class="mb-6 mx-32">
@@ -126,6 +122,7 @@
 import { format } from 'date-fns'
 import { useRouter } from 'vue-router'
 import { useGlobalStore } from '../store/global'
+import LoadingAnimation from './LoadingAnimation'
 
 const router = useRouter()
 const { simulation } = useGlobalStore()

--- a/app/javascript/src/composables/useFormat.js
+++ b/app/javascript/src/composables/useFormat.js
@@ -1,0 +1,17 @@
+import { useCurrencyFormat, useIntlNumberFormat } from 'vue-composable'
+
+export function useFormat() {
+  const lang = 'jp'
+  const yenOption = { currency: 'JPY', currencyDisplay: 'symbol' }
+  const percentOption = { style: 'decimal', minimumFractionDigits: 2 }
+  const { formatString: formatYen } = useCurrencyFormat(yenOption, lang)
+  const { formatString: formatPercent } = useIntlNumberFormat(
+    percentOption,
+    lang
+  )
+
+  return {
+    formatYen,
+    formatPercent
+  }
+}

--- a/app/javascript/src/composables/useInsurances.js
+++ b/app/javascript/src/composables/useInsurances.js
@@ -1,0 +1,46 @@
+import { ref } from 'vue'
+
+export const useInsurances = () => {
+  const insurances = ref([])
+  const totalPages = ref(0)
+
+  const getInsurances = async (query) => {
+    const insurancesAPI = `/api/insurances.json?${query}`
+    const response = await fetch(insurancesAPI, {
+      method: 'GET',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+      redirect: 'manual'
+    })
+    const json = await response
+      .json()
+      .catch((e) => console.warn('Failed to parsing', e))
+    insurances.value = json.insurance
+    totalPages.value = parseInt(json.totalPages)
+  }
+
+  const token = () => {
+    const meta = document.querySelector('meta[name="csrf-token"]')
+    return meta ? meta.getAttribute('content') : ''
+  }
+
+  const deleteInsurance = async (insuranceId) => {
+    const insuranceAPI = `/api/insurances/${insuranceId}`
+    await fetch(insuranceAPI, {
+      method: 'DELETE',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-Token': token()
+      },
+      credentials: 'same-origin',
+      redirect: 'manual'
+    })
+  }
+
+  return {
+    insurances,
+    totalPages,
+    getInsurances,
+    deleteInsurance
+  }
+}

--- a/app/javascript/src/composables/usePensions.js
+++ b/app/javascript/src/composables/usePensions.js
@@ -1,0 +1,46 @@
+import { ref } from 'vue'
+
+export const usePensions = () => {
+  const pensions = ref([])
+  const totalPages = ref(0)
+
+  const getPensions = async (query) => {
+    const pensionsAPI = `/api/pensions.json?${query}`
+    const response = await fetch(pensionsAPI, {
+      method: 'GET',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+      redirect: 'manual'
+    })
+    const json = await response
+      .json()
+      .catch((e) => console.warn('Failed to parsing', e))
+    pensions.value = json.pensions
+    totalPages.value = parseInt(json.totalPages)
+  }
+
+  const token = () => {
+    const meta = document.querySelector('meta[name="csrf-token"]')
+    return meta ? meta.getAttribute('content') : ''
+  }
+
+  const deletePension = async (pensionId) => {
+    const pensionAPI = `/api/pensions/${pensionId}`
+    await fetch(pensionAPI, {
+      method: 'DELETE',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-Token': token()
+      },
+      credentials: 'same-origin',
+      redirect: 'manual'
+    })
+  }
+
+  return {
+    pensions,
+    totalPages,
+    getPensions,
+    deletePension
+  }
+}

--- a/app/javascript/src/composables/useToast.js
+++ b/app/javascript/src/composables/useToast.js
@@ -1,0 +1,16 @@
+import Swal from 'sweetalert2'
+
+export const useToast = () => {
+  const toast = (title) => {
+    Swal.fire({
+      title: title,
+      toast: true,
+      position: 'top-end',
+      showConfirmButton: false,
+      timer: 3000,
+      timerProgressBar: true
+    })
+  }
+
+  return { toast }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "tailwindcss": "^3.0.7",
     "vee-validate": "^4.5.8",
     "vue": "^3.2.26",
+    "vue-composable": "^1.0.0-beta.24",
     "vue-loader": "^17.0.0",
     "vue-router": "4",
     "vue-template-compiler": "^2.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,6 +1765,11 @@
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.12.tgz#7b57cce215ae9f37a86984633b3aa3d595aa5b46"
   integrity sha512-iO/4FIezHKXhiDBdKySCvJVh8/mZPxHpiQrTy+PXVqJZgpTPTdHy4q8GXulaY+UKEagdkBb0onxNQZ0LNiqVhw==
 
+"@vue/devtools-api@^6.0.0-beta.19":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.1.3.tgz#a44c52e8fa6d22f84db3abdcdd0be5135b7dd7cf"
+  integrity sha512-79InfO2xHv+WHIrH1bHXQUiQD/wMls9qBk6WVwGCbdwP7/3zINtvqPNMtmSHXsIKjvUAHc8L0ouOj6ZQQRmcXg==
+
 "@vue/reactivity-transform@3.2.26":
   version "3.2.26"
   resolved "https://registry.yarnpkg.com/@vue/reactivity-transform/-/reactivity-transform-3.2.26.tgz#6d8f20a4aa2d19728f25de99962addbe7c4d03e9"
@@ -9684,6 +9689,13 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vue-composable@^1.0.0-beta.24:
+  version "1.0.0-beta.24"
+  resolved "https://registry.yarnpkg.com/vue-composable/-/vue-composable-1.0.0-beta.24.tgz#04032163fb90adfb4c1f0f5d962f9bca00398341"
+  integrity sha512-rVxqIk+CCBDNlu7MK59FB6hIHbjpaNszSZ3o1fReXiDKpdw2AAnSWx5vqUpJgC4yGlUzBMJ2eUQIjij5/wr8Kg==
+  dependencies:
+    "@vue/devtools-api" "^6.0.0-beta.19"
 
 vue-demi@*:
   version "0.12.1"


### PR DESCRIPTION
Closes: #169 

## やったこと

対象は管理系画面（Insurances、Pensions）

- `script`を`script setup`に修正
- プラグイン：vue-composableを導入
- 以下をcomposablesに抽出
    - toast
    - insurancesのAPIコール
    - pensionsのAPIコール
    - format処理
- ローディングアニメーションをコンポーネントに抽出
- 不要なdivタグを削除し、HTMLをセマンティックにした

## 申し送り事項

- このPRから、formatを自前実装からvue-composableに切り替えました。自前で実装してもそこまで実装コストは高くないですが、テストを書くコストが下がるのが理由です（特に管理画面は多少見た目がずれたとしても自分にしか影響がないため、維持コストを下げる方が望ましいと考えます）

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
