### PR TITLE
chore: validationSchemaをpropsから直接参照に変更

### DIFF
--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -1,11 +1,11 @@
 <template>
   <form class="mt-20" @submit="onSubmit">
     <div class="flex">
-      <h2>
+      <div>
         <span class="text-6xl text-primary">{{ displayStep }}</span>
         <span class="text-3xl font-semi-bold text-gray"> / </span>
         <span class="text-4xl text-primary">{{ zeroPadStepCounter }}</span>
-      </h2>
+      </div>
       <ProgressBar :top="current" :bottom="steps - 1" />
     </div>
     <div class="px-24 m-16 text-center">
@@ -32,15 +32,9 @@ import { useForm } from 'vee-validate'
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGlobalStore } from '../store/global'
+import { useValidationSchema } from '../composables/useValidationSchema'
 
 const emit = defineEmits(['next', 'submit'])
-const props = defineProps({
-  validationSchema: {
-    type: Object,
-    required: true
-  }
-})
-
 const { simulation } = useGlobalStore()
 const router = useRouter()
 
@@ -50,14 +44,13 @@ const next = $computed(() => simulation.nextStep.value)
 const steps = $computed(() => simulation.steps)
 const params = $computed(() => simulation.params)
 
+const validationSchema = useValidationSchema(new Date(params.simulationDate))
 const displayStep = computed(() => ('00' + (current + 1)).slice(-2))
 const nextStep = computed(() => (next ? 'つぎの質問へ' : '計算結果へ'))
 const zeroPadStepCounter = computed(() => ('00' + steps).slice(-2))
 
 const { resetForm, handleSubmit } = useForm({
-  validationSchema: computed(
-    () => props.validationSchema[simulation.currentStep]
-  )
+  validationSchema: computed(() => validationSchema[simulation.currentStep])
 })
 
 const onSubmit = handleSubmit((values) => {

--- a/app/javascript/src/components/SimulationForm.vue
+++ b/app/javascript/src/components/SimulationForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container mx-auto">
-    <FormWizard :validation-schema="validationSchema" @submit="onSubmit">
+    <FormWizard @submit="onSubmit">
       <router-view></router-view>
     </FormWizard>
   </div>
@@ -8,15 +8,9 @@
 
 <script setup>
 import FormWizard from './FormWizard'
-import { useValidationSchema } from '../composables/useValidationSchema'
 import { useRouter } from 'vue-router'
-import { useGlobalStore } from '../store/global'
 
-const { simulation } = useGlobalStore()
-const params = $computed(() => simulation.params)
 const router = useRouter()
-
-const validationSchema = useValidationSchema(new Date(params.simulationDate))
 
 const onSubmit = () => router.push('/simulations')
 </script>


### PR DESCRIPTION
globalStoreの値を利用できるため、あえてpropsで渡す必要がなくなったから

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
