### PR TITLE
エラーメッセージの表示位置によってフォームの高さが変わらないように修正

### DIFF
--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -4,10 +4,10 @@
       <ProgressStep :top="current + 1" :bottom="steps" />
       <ProgressBar :top="current" :bottom="steps - 1" />
     </div>
-    <div class="px-24 m-16 text-center">
-      <slot />
+    <div class="h-80 px-24 m-12 text-center">
+      <router-view></router-view>
     </div>
-    <div class="flex justify-evenly">
+    <div class="flex px-24 justify-evenly">
       <button class="prev-button" v-if="prev" type="button" @click="goToPrev">
         まえの質問へ
       </button>

--- a/app/javascript/src/components/SimulationForm.vue
+++ b/app/javascript/src/components/SimulationForm.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="container mx-auto">
-    <FormWizard @submit="onSubmit">
-      <router-view></router-view>
-    </FormWizard>
+    <FormWizard @submit="onSubmit" />
   </div>
 </template>
 
@@ -17,19 +15,27 @@ const onSubmit = () => router.push('/simulations')
 
 <style scope>
 .form-label {
-  @apply text-4xl inline-block mb-12;
+  @apply h-20 text-4xl inline-block mb-2;
 }
 
 .form-field {
-  @apply px-6 py-2 w-9/12 rounded-md border-4 border-boundaryBlack focus:border-primary tracking-widest text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
+  @apply px-6 py-2 w-9/12 rounded-md border-4 border-boundaryBlack focus:border-gray tracking-widest text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
+}
+
+.form-field-error {
+  @apply px-6 py-2 w-9/12 rounded-md border-4 border-red-600 tracking-widest text-5xl outline-none leading-8 placeholder-boundaryBlack;
+}
+
+.form-field-success {
+  @apply px-6 py-2 w-9/12 rounded-md border-4 border-primary tracking-widest text-5xl outline-none leading-8 placeholder-boundaryBlack;
 }
 
 .form-tips {
-  @apply mt-4 text-sm text-gray;
+  @apply mt-2 text-sm text-gray;
 }
 
 .form-error {
-  @apply flex justify-center text-red-500 mt-2;
+  @apply flex h-6 justify-center text-red-500 mb-2;
 }
 
 .form-supplement {

--- a/app/javascript/src/components/SimulationForm.vue
+++ b/app/javascript/src/components/SimulationForm.vue
@@ -15,19 +15,15 @@ const onSubmit = () => router.push('/simulations')
 
 <style scope>
 .form-label {
-  @apply h-20 text-4xl inline-block mb-2;
+  @apply h-24 text-4xl inline-block mb-2;
 }
 
 .form-field {
-  @apply px-6 py-2 w-9/12 rounded-md border-4 border-boundaryBlack focus:border-gray tracking-widest text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
+  @apply px-6 py-2 w-9/12 rounded-md border-4 border-boundaryBlack focus:border-primary tracking-widest text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
 }
 
 .form-field-error {
-  @apply px-6 py-2 w-9/12 rounded-md border-4 border-red-600 tracking-widest text-5xl outline-none leading-8 placeholder-boundaryBlack;
-}
-
-.form-field-success {
-  @apply px-6 py-2 w-9/12 rounded-md border-4 border-primary tracking-widest text-5xl outline-none leading-8 placeholder-boundaryBlack;
+  @apply px-6 py-2 w-9/12 rounded-md border-4 border-red-500 focus:border-red-600 tracking-widest text-5xl outline-none leading-8 placeholder-boundaryBlack;
 }
 
 .form-tips {

--- a/app/javascript/src/components/simulation_form/Age.vue
+++ b/app/javascript/src/components/simulation_form/Age.vue
@@ -1,14 +1,17 @@
 <template>
   <label for="age" class="form-label">年齢を教えてください</label>
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error }}</span>
+  </p>
   <input
     id="age"
     class="form-field text-right"
     type="text"
     :value="age"
+    :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     placeholder="30"
   /><span class="form-supplement">歳</span>
-  <p class="form-error">{{ error }}</p>
 </template>
 
 <script setup>

--- a/app/javascript/src/components/simulation_form/EmploymentMonth.vue
+++ b/app/javascript/src/components/simulation_form/EmploymentMonth.vue
@@ -2,12 +2,16 @@
   <label for="employmentMonth" class="form-label"
     >転職予定月を教えてください</label
   >
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error }}</span>
+  </p>
   <input
     id="employmentMonth"
     class="form-field text-center"
     type="text"
     v-maska="{ mask: '####/##' }"
     :value="employmentMonth"
+    :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     placeholder="2022/02"
   />
@@ -15,7 +19,6 @@
     <i class="fas fa-info-circle mr-2"></i>計算可能な範囲：
     {{ `${from} ~ ${to}` }}
   </p>
-  <p class="form-error">{{ error }}</p>
 </template>
 
 <script setup>

--- a/app/javascript/src/components/simulation_form/PostalCode.vue
+++ b/app/javascript/src/components/simulation_form/PostalCode.vue
@@ -2,12 +2,16 @@
   <label for="postalCode" class="form-label whitespace-nowrap">
     お住まいの地域の郵便番号を教えてください
   </label>
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error || addressError }}</span>
+  </p>
   <input
     id="postalCode"
     class="form-field text-center"
     type="text"
     v-maska="{ mask: '###-####' }"
     :value="postalCode"
+    :class="error || addressError ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     @blur="setAddress"
     placeholder="100-0004"
@@ -15,8 +19,6 @@
   <p class="form-tips">
     <i class="fas fa-info-circle mr-2"></i>お住まいの地域： {{ address }}
   </p>
-  <p class="form-error">{{ error }}</p>
-  <p v-if="!error" class="form-error">{{ addressError }}</p>
 </template>
 
 <script setup>

--- a/app/javascript/src/components/simulation_form/PreviousSalary.vue
+++ b/app/javascript/src/components/simulation_form/PreviousSalary.vue
@@ -3,11 +3,15 @@
     <span class="inline-block">{{ `昨昨年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「所得」を教えてください</span>
   </label>
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error }}</span>
+  </p>
   <input
     id="previousSalary"
     class="form-field text-right"
     type="text"
     :value="previousSalary"
+    :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     v-maska="{ mask: '#*' }"
     placeholder="500000"
@@ -16,7 +20,6 @@
     <i class="fas fa-info-circle mr-2"></i
     >所得額は住民税決定通知書の「給与所得（所得金額調整控除後）」の値です
   </p>
-  <p class="form-error">{{ error }}</p>
 </template>
 
 <script setup>

--- a/app/javascript/src/components/simulation_form/PreviousSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/PreviousSocialInsurance.vue
@@ -3,11 +3,15 @@
     <span class="inline-block">{{ `昨年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「社会保険料」を教えてください</span>
   </label>
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error }}</span>
+  </p>
   <input
     id="previousSocialInsurance"
     class="form-field text-right"
     type="text"
     :value="previousSocialInsurance"
+    :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     v-maska="{ mask: '#*' }"
     placeholder="500000"
@@ -16,7 +20,6 @@
     <i class="fas fa-info-circle mr-2"></i
     >住民税の総額は、住民税決定通知書の「社会保険料」の値です
   </p>
-  <p class="form-error">{{ error }}</p>
   <InsuranceCompleteButton
     :salary="previousSalary"
     @completeInsurance="completeInsurance"

--- a/app/javascript/src/components/simulation_form/RetirementMonth.vue
+++ b/app/javascript/src/components/simulation_form/RetirementMonth.vue
@@ -2,12 +2,16 @@
   <label for="retirementMonth" class="form-label"
     >退職予定月を教えてください</label
   >
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error }}</span>
+  </p>
   <input
     id="retirementMonth"
-    class="form-field text-center"
+    class="text-center"
     type="text"
     v-maska="{ mask: '####/##' }"
     :value="retirementMonth"
+    :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     placeholder="2022/02"
   />
@@ -15,7 +19,6 @@
     <i class="fas fa-info-circle mr-2"></i>計算可能な範囲：
     {{ `${from} ~ ${to}` }}
   </p>
-  <p class="form-error">{{ error }}</p>
 </template>
 
 <script setup>

--- a/app/javascript/src/components/simulation_form/Salary.vue
+++ b/app/javascript/src/components/simulation_form/Salary.vue
@@ -3,11 +3,15 @@
     <span class="inline-block">{{ `昨年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「所得」を教えてください</span>
   </label>
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error }}</span>
+  </p>
   <input
     id="salary"
     class="form-field text-right"
     type="text"
     :value="salary"
+    :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     v-maska="{ mask: '#*' }"
     placeholder="500000"
@@ -16,7 +20,6 @@
     <i class="fas fa-info-circle mr-2"></i
     >所得額は住民税決定通知書の「給与所得（所得金額調整控除後）」の値です
   </p>
-  <p class="form-error">{{ error }}</p>
 </template>
 
 <script setup>

--- a/app/javascript/src/components/simulation_form/ScheduledSalary.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSalary.vue
@@ -3,11 +3,15 @@
     <span class="inline-block">{{ `今年度（${from} ~ ${to}）` }}の</span
     ><span class="inline-block">「予定所得額」を教えてください</span>
   </label>
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error }}</span>
+  </p>
   <input
     id="scheduledSalary"
     class="form-field text-right"
     type="text"
     :value="scheduledSalary"
+    :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     v-maska="{ mask: '#*' }"
     placeholder="500000"
@@ -16,7 +20,6 @@
     <i class="fas fa-info-circle mr-2"></i
     >予定所得額は「退職するまでの毎月の給与（満額）」と「賞与（満額）」の合計です
   </p>
-  <p class="form-error">{{ error }}</p>
 </template>
 
 <script setup>

--- a/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
@@ -3,11 +3,15 @@
     <span class="inline-block">{{ `今年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「予定社会保険料」を教えてください</span>
   </label>
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error }}</span>
+  </p>
   <input
     id="scheduledSalary"
     class="form-field text-right"
     type="text"
     :value="scheduledSocialInsurance"
+    :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     v-maska="{ mask: '#*' }"
     placeholder="500000"
@@ -28,7 +32,6 @@
       </ul>
     </div>
   </div>
-  <p class="form-error">{{ error }}</p>
   <InsuranceCompleteButton
     :salary="scheduledSalary"
     @completeInsurance="completeInsurance"

--- a/app/javascript/src/components/simulation_form/SocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/SocialInsurance.vue
@@ -3,11 +3,15 @@
     <span class="inline-block">{{ `昨年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「社会保険料」を教えてください</span>
   </label>
+  <p class="mb-1 w-9/12 mx-auto text-right">
+    <span class="ml-2 text-red-600">{{ error }}</span>
+  </p>
   <input
     id="socialInsurance"
-    class="form-field text-right"
+    class="text-right"
     type="text"
     :value="socialInsurance"
+    :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     v-maska="{ mask: '#*' }"
     placeholder="500000"
@@ -16,11 +20,10 @@
     <i class="fas fa-info-circle mr-2"></i
     >住民税の総額は、住民税決定通知書の「社会保険料」の値です
   </p>
-  <p class="form-error">{{ error }}</p>
   <InsuranceCompleteButton
     :salary="salary"
     @completeInsurance="completeInsurance"
-    class="mt-2"
+    class="mt-4"
   />
 </template>
 


### PR DESCRIPTION
Closes: #196 

## 目的

エラーメッセージの表示有無によってボタンの位置が変わり、操作がしづらいため、エラーメッセージの表示領域をフォーム右上に固定する。
視線誘導的にはフォーム左右または下の方が好ましいが、ウィザードで表示していることとフォームの説明と重複することから右上に配置している。

## UIの修正

### 変更前

![CleanShot 2022-03-21 at 09 41 15](https://user-images.githubusercontent.com/61409641/159193069-bcabce72-92c7-45bf-bff4-341bdf41fea2.gif)

### 変更後

![CleanShot 2022-03-21 at 09 45 47](https://user-images.githubusercontent.com/61409641/159193242-01bcb6d0-d8c0-4ab4-ac88-4f1e752e6f48.gif)

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
