### PR TITLE
所得額、社会保険料の文言を修正

### DIFF
--- a/app/javascript/src/components/simulation_form/PreviousSalary.vue
+++ b/app/javascript/src/components/simulation_form/PreviousSalary.vue
@@ -1,7 +1,7 @@
 <template>
   <label for="previousSalary" class="form-label">
     <span class="inline-block">{{ `昨昨年度（${from} ~ ${to}）の` }}</span
-    ><span class="inline-block">「所得」を教えてください</span>
+    ><span class="inline-block">「所得額」を教えてください</span>
   </label>
   <p class="mb-1 w-9/12 mx-auto text-right">
     <span class="ml-2 text-red-600">{{ error }}</span>
@@ -18,7 +18,7 @@
   />
   <p class="form-tips">
     <i class="fas fa-info-circle mr-2"></i
-    >所得額は住民税決定通知書の「給与所得（所得金額調整控除後）」の値です
+    >昨昨年度の所得額は住民税決定通知書の「給与所得（所得金額調整控除後）」の値です
   </p>
 </template>
 

--- a/app/javascript/src/components/simulation_form/PreviousSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/PreviousSocialInsurance.vue
@@ -18,7 +18,7 @@
   />
   <p class="form-tips">
     <i class="fas fa-info-circle mr-2"></i
-    >住民税の総額は、住民税決定通知書の「社会保険料」の値です
+    >昨昨年度の社会保険料は、住民税決定通知書の「社会保険料」の値です
   </p>
   <InsuranceCompleteButton
     :salary="previousSalary"

--- a/app/javascript/src/components/simulation_form/Salary.vue
+++ b/app/javascript/src/components/simulation_form/Salary.vue
@@ -1,7 +1,7 @@
 <template>
   <label for="salary" class="form-label">
     <span class="inline-block">{{ `昨年度（${from} ~ ${to}）の` }}</span
-    ><span class="inline-block">「所得」を教えてください</span>
+    ><span class="inline-block">「所得額」を教えてください</span>
   </label>
   <p class="mb-1 w-9/12 mx-auto text-right">
     <span class="ml-2 text-red-600">{{ error }}</span>
@@ -18,7 +18,7 @@
   />
   <p class="form-tips">
     <i class="fas fa-info-circle mr-2"></i
-    >所得額は住民税決定通知書の「給与所得（所得金額調整控除後）」の値です
+    >昨年度の所得額は住民税決定通知書の「給与所得（所得金額調整控除後）」の値です
   </p>
 </template>
 

--- a/app/javascript/src/components/simulation_form/ScheduledSalary.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSalary.vue
@@ -1,7 +1,7 @@
 <template>
   <label for="scheduledSalary" class="form-label">
     <span class="inline-block">{{ `今年度（${from} ~ ${to}）` }}の</span
-    ><span class="inline-block">「予定所得額」を教えてください</span>
+    ><span class="inline-block">「所得額」を教えてください</span>
   </label>
   <p class="mb-1 w-9/12 mx-auto text-right">
     <span class="ml-2 text-red-600">{{ error }}</span>
@@ -18,7 +18,7 @@
   />
   <p class="form-tips">
     <i class="fas fa-info-circle mr-2"></i
-    >予定所得額は「退職するまでの毎月の給与（満額）」と「賞与（満額）」の合計です
+    >今年度の所得額は「退職するまでの毎月の給与（満額）」と「賞与（満額）」の合計です
   </p>
 </template>
 
@@ -34,6 +34,7 @@ const { simulation } = useGlobalStore()
 const params = $computed(() => simulation.params)
 
 const base = new Date(params.simulationDate)
+
 const { beginningOfYear, endOfYear } = useFinancialYear(base, 1, 4)
 const from = format(beginningOfYear, 'yyyy年M月d日')
 const to = format(endOfYear, 'yyyy年M月d日')

--- a/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
@@ -1,7 +1,7 @@
 <template>
   <label for="scheduledSalary" class="form-label">
     <span class="inline-block">{{ `今年度（${from} ~ ${to}）の` }}</span
-    ><span class="inline-block">「予定社会保険料」を教えてください</span>
+    ><span class="inline-block">「社会保険料」を教えてください</span>
   </label>
   <p class="mb-1 w-9/12 mx-auto text-right">
     <span class="ml-2 text-red-600">{{ error }}</span>
@@ -21,7 +21,7 @@
       <i class="fas fa-info-circle mr-2"></i>
     </div>
     <div class="text-left">
-      <p>予定社会保険料は以下の合計です。</p>
+      <p>今年度の社会保険料は以下の合計です。</p>
       <ul class="list-disc pl-6 pt-0.5">
         <li>
           退職するまでの毎月の「社会保険料」「厚生年金保険料」「雇用保険料」

--- a/app/javascript/src/components/simulation_form/SocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/SocialInsurance.vue
@@ -18,7 +18,7 @@
   />
   <p class="form-tips">
     <i class="fas fa-info-circle mr-2"></i
-    >住民税の総額は、住民税決定通知書の「社会保険料」の値です
+    >昨年度の社会保険料は、住民税決定通知書の「社会保険料」の値です
   </p>
   <InsuranceCompleteButton
     :salary="salary"


### PR DESCRIPTION
「予定」はタイミングによって意味がわからなくなるため、質問としては単純に「所得額」「社会保険料」として統一した

Closes: #198


---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
