### PR TITLE
退職予定月と転職予定月のプレースホルダーを動的に変更

### DIFF
--- a/app/javascript/src/components/simulation_form/EmploymentMonth.vue
+++ b/app/javascript/src/components/simulation_form/EmploymentMonth.vue
@@ -13,7 +13,7 @@
     :value="employmentMonth"
     :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
-    placeholder="2022/02"
+    :placeholder="to"
   />
   <p class="form-tips">
     <i class="fas fa-info-circle mr-2"></i>計算可能な範囲：

--- a/app/javascript/src/components/simulation_form/RetirementMonth.vue
+++ b/app/javascript/src/components/simulation_form/RetirementMonth.vue
@@ -13,7 +13,7 @@
     :value="retirementMonth"
     :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
-    placeholder="2022/02"
+    :placeholder="from"
   />
   <p class="form-tips">
     <i class="fas fa-info-circle mr-2"></i>計算可能な範囲：


### PR DESCRIPTION
固定値だと古い日付でも入力できると錯覚するため

Closes: #206


---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
