### PR TITLE
Railsを事前起動しなくても、Cypressを実行できるように修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,7 @@ jobs:
       - name: Jest
         run: docker-compose run web yarn test
       - name: Cypress
-        run: |
-          docker-compose up -d web
-          docker-compose exec -T web rails s -d
-          docker-compose up --exit-code-from cypress
+        run: docker-compose -f docker-compose.yml -f cypress.yml up --exit-code-from cypress
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/bin/cypress
+++ b/bin/cypress
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose -f docker-compose.yml -f cypress.yml up --exit-code-from cypress

--- a/cypress.yml
+++ b/cypress.yml
@@ -1,0 +1,5 @@
+version: '3.2'
+
+services:
+  web:
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -d -p 3000 -b '0.0.0.0' && bin/webpack-dev-server"


### PR DESCRIPTION
Cypressによるテストを実行する場合、事前にRailsが起動している必要があったが、これが煩わしかったため。

別途commandをオーバーライドするdocker-composeを作成し、それを利用するbinstubを用意することで、事前にRailsを立ち上げることなく、コマンド1つでテストを実行できるようにした。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
