### PR TITLE
シミュレーション画面のE2Eテストを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,11 @@ jobs:
       - name: Jest
         run: docker-compose run web yarn test
       - name: Cypress
-        run: docker-compose -f docker-compose.yml -f cypress.yml up --exit-code-from cypress
+        run: |
+          docker-compose up -d web
+          docker-compose exec -T web bin/webpack
+          docker-compose exec -T web rails s -d
+          docker-compose up --exit-code-from cypress
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/app/javascript/src/components/simulation_form/PostalCode.vue
+++ b/app/javascript/src/components/simulation_form/PostalCode.vue
@@ -13,7 +13,6 @@
     :value="postalCode"
     :class="error || addressError ? 'form-field-error' : 'form-field'"
     @change="handleChange"
-    @blur="setAddress"
     placeholder="100-0004"
   />
   <p class="form-tips">
@@ -22,7 +21,7 @@
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
 import { useField } from 'vee-validate'
 import axios from 'axios'
@@ -39,7 +38,7 @@ let {
 } = useField('postalCode')
 let { value: address, errorMessage: addressError } = useField('address')
 
-const setAddress = async () => {
+watchEffect(async () => {
   address.value = ''
 
   if (!postalCode.value) return
@@ -61,11 +60,10 @@ const setAddress = async () => {
   } catch (err) {
     console.warn(err)
   }
-}
+})
 
 onMounted(async () => {
   postalCode.value = params.postalCode
   simulation.setCurrentStep(useRoute().name)
-  if (postalCode.value) await setAddress()
 })
 </script>

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,4 +1,6 @@
 {
   "pluginsFile": false,
-  "supportFile": false
+  "supportFile": false,
+  "viewportWidth": 1200,
+  "viewportHeight": 960
 }

--- a/e2e/cypress/integration/App.spec.js
+++ b/e2e/cypress/integration/App.spec.js
@@ -1,3 +1,0 @@
-it('sample', () => {
-  cy.visit('/')
-})

--- a/e2e/cypress/integration/simulation.spec.js
+++ b/e2e/cypress/integration/simulation.spec.js
@@ -25,8 +25,9 @@ describe('Simulation', () => {
 
           cy.contains('郵便番号').should('be.visible')
           cy.get('input').type('1000004{enter}')
-          cy.contains('つぎの質問へ').click()
           cy.wait(500)
+          cy.contains('つぎの質問へ').click()
+          cy.contains('つぎの質問へ').click()
           cy.contains('つぎの質問へ').click()
 
           cy.contains('昨昨年度').should('be.visible')
@@ -73,6 +74,8 @@ describe('Simulation', () => {
 
           cy.contains('郵便番号').should('be.visible')
           cy.get('input').type('1000004{enter}')
+          cy.wait(500)
+          cy.contains('つぎの質問へ').click()
           cy.contains('つぎの質問へ').click()
           cy.contains('つぎの質問へ').click()
 
@@ -110,6 +113,8 @@ describe('Simulation', () => {
 
           cy.contains('郵便番号').should('be.visible')
           cy.get('input').type('1000004{enter}')
+          cy.wait(500)
+          cy.contains('つぎの質問へ').click()
           cy.contains('つぎの質問へ').click()
           cy.contains('つぎの質問へ').click()
 
@@ -155,6 +160,8 @@ describe('Simulation', () => {
 
         cy.contains('郵便番号').should('be.visible')
         cy.get('input').type('1000004{enter}')
+        cy.wait(500)
+        cy.contains('つぎの質問へ').click()
         cy.contains('つぎの質問へ').click()
         cy.contains('つぎの質問へ').click()
 

--- a/e2e/cypress/integration/simulation.spec.js
+++ b/e2e/cypress/integration/simulation.spec.js
@@ -1,0 +1,173 @@
+describe('Simulation', () => {
+  describe('dynamic step', () => {
+    beforeEach(() => {
+      cy.clock(new Date(2022, 3, 15), ['Date']) // 日本時間午前9
+    })
+
+    context(
+      'when retirementMonth < June and employmentMonth < next April',
+      () => {
+        it('should show 8 questions(essential + previous + current)', () => {
+          cy.visit('/')
+          cy.contains('いますぐ計算する').click()
+
+          cy.contains('退職予定月').should('be.visible')
+          cy.get('input').type('202204')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('転職予定月').should('be.visible')
+          cy.get('input').type('202303')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('年齢').should('be.visible')
+          cy.get('input').type('20')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('郵便番号').should('be.visible')
+          cy.get('input').type('1000004{enter}')
+          cy.contains('つぎの質問へ').click()
+          cy.wait(500)
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('昨昨年度').should('be.visible')
+          cy.contains('所得').should('be.visible')
+          cy.get('input').type('5000000')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('昨昨年度').should('be.visible')
+          cy.contains('社会保険料').should('be.visible')
+          cy.contains('おまかせで入力する').click()
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('昨年度').should('be.visible')
+          cy.contains('所得').should('be.visible')
+          cy.get('input').type('5000000')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('昨年度').should('be.visible')
+          cy.contains('社会保険料').should('be.visible')
+          cy.contains('おまかせで入力する').click()
+          cy.contains('計算結果へ').should('be.visible')
+        })
+      }
+    )
+
+    context(
+      'when retirementMonth >= June and < next June, and employmentMonth < next April',
+      () => {
+        it('should show 6 questions(essential + current)', () => {
+          cy.visit('/')
+          cy.contains('いますぐ計算する').click()
+
+          cy.contains('退職予定月').should('be.visible')
+          cy.get('input').type('202206')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('転職予定月').should('be.visible')
+          cy.get('input').type('202303')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('年齢').should('be.visible')
+          cy.get('input').type('20')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('郵便番号').should('be.visible')
+          cy.get('input').type('1000004{enter}')
+          cy.contains('つぎの質問へ').click()
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('昨年度').should('be.visible')
+          cy.contains('所得').should('be.visible')
+          cy.get('input').type('5000000')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('昨年度').should('be.visible')
+          cy.contains('社会保険料').should('be.visible')
+          cy.contains('おまかせで入力する').click()
+          cy.contains('計算結果へ').should('be.visible')
+        })
+      }
+    )
+
+    context(
+      'when retirementMonth >= June and < next June, and employmentMonth > next April',
+      () => {
+        it('should show 8 questions(essential + current + scheduled)', () => {
+          cy.visit('/')
+          cy.contains('いますぐ計算する').click()
+
+          cy.contains('退職予定月').should('be.visible')
+          cy.get('input').type('202305')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('転職予定月').should('be.visible')
+          cy.get('input').type('202404')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('年齢').should('be.visible')
+          cy.get('input').type('20')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('郵便番号').should('be.visible')
+          cy.get('input').type('1000004{enter}')
+          cy.contains('つぎの質問へ').click()
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('昨年度').should('be.visible')
+          cy.contains('所得').should('be.visible')
+          cy.get('input').type('5000000')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('昨年度').should('be.visible')
+          cy.contains('社会保険料').should('be.visible')
+          cy.contains('おまかせで入力する').click()
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('今年度').should('be.visible')
+          cy.contains('所得').should('be.visible')
+          cy.get('input').type('5000000')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('今年度').should('be.visible')
+          cy.contains('社会保険料').should('be.visible')
+          cy.contains('おまかせで入力する').click()
+          cy.contains('計算結果へ').should('be.visible')
+        })
+      }
+    )
+
+    context('when retirementMonth >= next June', () => {
+      it('should show 6 questions(essential + scheduled)', () => {
+        cy.visit('/')
+        cy.contains('いますぐ計算する').click()
+
+        cy.contains('退職予定月').should('be.visible')
+        cy.get('input').type('202306')
+        cy.contains('つぎの質問へ').click()
+
+        cy.contains('転職予定月').should('be.visible')
+        cy.get('input').type('202404')
+        cy.contains('つぎの質問へ').click()
+
+        cy.contains('年齢').should('be.visible')
+        cy.get('input').type('20')
+        cy.contains('つぎの質問へ').click()
+
+        cy.contains('郵便番号').should('be.visible')
+        cy.get('input').type('1000004{enter}')
+        cy.contains('つぎの質問へ').click()
+        cy.contains('つぎの質問へ').click()
+
+        cy.contains('今年度').should('be.visible')
+        cy.contains('所得').should('be.visible')
+        cy.get('input').type('5000000')
+        cy.contains('つぎの質問へ').click()
+
+        cy.contains('今年度').should('be.visible')
+        cy.contains('社会保険料').should('be.visible')
+        cy.contains('おまかせで入力する').click()
+        cy.contains('計算結果へ').should('be.visible')
+      })
+    })
+  })
+})

--- a/e2e/cypress/integration/simulation.spec.js
+++ b/e2e/cypress/integration/simulation.spec.js
@@ -24,10 +24,7 @@ describe('Simulation', () => {
           cy.contains('つぎの質問へ').click()
 
           cy.contains('郵便番号').should('be.visible')
-          cy.get('input').type('1000004{enter}')
-          cy.wait(500)
-          cy.contains('つぎの質問へ').click()
-          cy.contains('つぎの質問へ').click()
+          cy.get('input').type('1000004')
           cy.contains('つぎの質問へ').click()
 
           cy.contains('昨昨年度').should('be.visible')
@@ -73,10 +70,7 @@ describe('Simulation', () => {
           cy.contains('つぎの質問へ').click()
 
           cy.contains('郵便番号').should('be.visible')
-          cy.get('input').type('1000004{enter}')
-          cy.wait(500)
-          cy.contains('つぎの質問へ').click()
-          cy.contains('つぎの質問へ').click()
+          cy.get('input').type('1000004')
           cy.contains('つぎの質問へ').click()
 
           cy.contains('昨年度').should('be.visible')
@@ -112,10 +106,7 @@ describe('Simulation', () => {
           cy.contains('つぎの質問へ').click()
 
           cy.contains('郵便番号').should('be.visible')
-          cy.get('input').type('1000004{enter}')
-          cy.wait(500)
-          cy.contains('つぎの質問へ').click()
-          cy.contains('つぎの質問へ').click()
+          cy.get('input').type('1000004')
           cy.contains('つぎの質問へ').click()
 
           cy.contains('昨年度').should('be.visible')
@@ -159,10 +150,7 @@ describe('Simulation', () => {
         cy.contains('つぎの質問へ').click()
 
         cy.contains('郵便番号').should('be.visible')
-        cy.get('input').type('1000004{enter}')
-        cy.wait(500)
-        cy.contains('つぎの質問へ').click()
-        cy.contains('つぎの質問へ').click()
+        cy.get('input').type('1000004')
         cy.contains('つぎの質問へ').click()
 
         cy.contains('今年度').should('be.visible')


### PR DESCRIPTION
## やったこと

- シミュレーション画面のE2Eテストを追加
  - バリデーションエラーはユニットテストに組み込んでいるので、正常系の動的ルーティングをテスト
  - その他については随時他の実装と合わせて追加する

## 申し送り事項

- 郵便番号から住所を検索するAPI部分がCIでは高確率で落ちる（ローカルだととおる）。このPRとしてはテストコードとして　正しい内容をPushし、CIとしては落ちるがマージする。別Issueで対応する。

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
