### PR TITLE
404ページを追加

### DIFF
--- a/app/javascript/src/components/NotFound.vue
+++ b/app/javascript/src/components/NotFound.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="container mx-auto pt-24 px-2">
+    <div
+      class="md:max-w-2xl mx-auto p-8 border-4 border-boundaryBlack rounded-xl"
+    >
+      <h1 class="text-xl md:text-3xl text-center mb-4">
+        ご指定のページが見つかりません
+      </h1>
+      <p
+        class="text-lg md:text-2xl text-center mb-6 underline underline-offset-8 decoration-4 decoration-primary"
+      >
+        404: Not Found
+      </p>
+      <p class="text-sm">
+        お探しのページは一時的にアクセスができない状況にあるか、移動もしくは削除された可能性があります。また、URL、ファイル名にタイプミスがないか再度ご確認ください。
+      </p>
+    </div>
+  </div>
+</template>

--- a/app/javascript/src/router/router.js
+++ b/app/javascript/src/router/router.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../components/Home'
+import NotFound from '../components/NotFound'
 import SimulationForm from '../components/SimulationForm'
 import SimulationResult from '../components/SimulationResult'
 import RetirementMonth from '../components/simulation_form/RetirementMonth.vue'
@@ -17,6 +18,7 @@ const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: '/', component: Home },
+    { path: '/:pathMatch(.*)*', component: NotFound },
     {
       path: '/simulations/new',
       component: SimulationForm,

--- a/e2e/cypress/integration/router.spec.js
+++ b/e2e/cypress/integration/router.spec.js
@@ -1,0 +1,8 @@
+describe('Router', () => {
+  context('when access page with invalid url', () => {
+    it('should show 404', () => {
+      cy.visit('/this-is-invalid-url')
+      cy.contains('404: Not Found').should('be.visible')
+    })
+  })
+})


### PR DESCRIPTION
Closes: #193

## やったこと

- 404ページを追加
    - Vue Router側で制御している
    - 参考：[Migrating from Vue 2 \| Vue Router](https://router.vuejs.org/guide/migration/#removed-star-or-catch-all-routes)

## UIの追加

404ページは以下の内容が表示されます

![image](https://user-images.githubusercontent.com/61409641/159916549-ab9ce058-3ea9-419b-92ba-1f451191aff0.png)


---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
