### PR TITLE
未回答のステップがある場合に先の画面に遷移できないよう修正

### DIFF
--- a/app/javascript/src/router/router.js
+++ b/app/javascript/src/router/router.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import globalStore from '../store/global'
 import Home from '../components/Home'
 import NotFound from '../components/NotFound'
 import SimulationForm from '../components/SimulationForm'
@@ -83,10 +84,26 @@ const router = createRouter({
     },
     {
       path: '/simulations',
+      name: 'Result',
       component: SimulationResult,
       meta: { title: 'シミュレーション結果' }
     }
   ]
+})
+
+router.beforeEach((to, from, next) => {
+  const { simulation } = globalStore()
+
+  if (to.name === 'Result' && !simulation.isFinished) {
+    router.push({ name: simulation.currentStep })
+  } else if (
+    !to.fullPath.indexOf('/simulations/new/') &&
+    !simulation.accessibleRoute.includes(to.name)
+  ) {
+    router.push({ name: simulation.currentStep })
+  } else {
+    next()
+  }
 })
 
 const DEFAULT_TITLE = 'quitcost'

--- a/app/javascript/src/store/simulation.js
+++ b/app/javascript/src/store/simulation.js
@@ -145,6 +145,26 @@ export default function simulationStore() {
       )
     },
 
+    get routes() {
+      return state.value.routes
+    },
+
+    get isFinished() {
+      return state.value.steps === state.value.currentStepIdx + 1
+    },
+
+    get accessibleRoute() {
+      const camelizeAnswer = Object.keys(state.value.params).map(
+        (route) => route[0].toUpperCase() + route.slice(1)
+      )
+      const completedRoute = camelizeAnswer.filter((route) =>
+        state.value.routes.includes(route)
+      )
+      const lastStep = state.value.routes.indexOf(completedRoute.at(-1)) + 1
+      const nextRoute = state.value.routes[lastStep]
+      return [...completedRoute, nextRoute]
+    },
+
     get result() {
       return state.value.result
     },

--- a/e2e/cypress/integration/router.spec.js
+++ b/e2e/cypress/integration/router.spec.js
@@ -1,8 +1,119 @@
 describe('Router', () => {
+  beforeEach(() => {
+    cy.clock(new Date(2022, 3, 15), ['Date'])
+  })
+
   context('when access page with invalid url', () => {
     it('should show 404', () => {
       cy.visit('/this-is-invalid-url')
       cy.contains('404: Not Found').should('be.visible')
     })
   })
+
+  context('when access result page without answering all questions', () => {
+    context('when current page is simulations/new/*', () => {
+      it('should redirect current step', () => {
+        cy.visit('/')
+        cy.contains('いますぐ計算する').click()
+
+        cy.contains('退職予定月').should('be.visible')
+        cy.get('input').type('202206')
+        cy.contains('つぎの質問へ').click()
+
+        cy.visit('/simulations')
+        cy.contains('転職予定月').should('be.visible')
+      })
+
+      it('should redirect current page even if press the back or next button', () => {
+        cy.visit('/')
+        cy.contains('いますぐ計算する').click()
+
+        cy.contains('退職予定月').should('be.visible')
+        cy.get('input').type('202206')
+        cy.contains('つぎの質問へ').click()
+
+        cy.contains('転職予定月').should('be.visible')
+        cy.get('input').type('202303')
+        cy.contains('つぎの質問へ').click()
+
+        cy.contains('まえの質問へ').click()
+        cy.contains('転職予定月').should('be.visible')
+
+        cy.contains('まえの質問へ').click()
+        cy.contains('退職予定月').should('be.visible')
+
+        cy.contains('つぎの質問へ').click()
+        cy.contains('転職予定月').should('be.visible')
+
+        cy.visit('/simulations')
+        cy.contains('転職予定月').should('be.visible')
+      })
+    })
+
+    context('when current page is NOT simulations/new/*', () => {
+      it('should redirect first step of simulation', () => {
+        cy.visit('/')
+        cy.contains('いますぐ計算する').click()
+        cy.contains('退職予定月').should('be.visible')
+
+        cy.visit('/simulations')
+        cy.contains('退職予定月').should('be.visible')
+      })
+    })
+  })
+
+  context(
+    'when access simulations/new/* without answering previous questions',
+    () => {
+      context('when current page is simulations/new/*', () => {
+        it('should redirect current step', () => {
+          cy.visit('/')
+          cy.contains('いますぐ計算する').click()
+
+          cy.contains('退職予定月').should('be.visible')
+          cy.get('input').type('202206')
+          cy.contains('つぎの質問へ').click()
+
+          cy.visit('/simulations/new/salary')
+          cy.contains('転職予定月').should('be.visible')
+        })
+
+        it('should redirect current page even if press the back or next button', () => {
+          cy.visit('/')
+          cy.contains('いますぐ計算する').click()
+
+          cy.contains('退職予定月').should('be.visible')
+          cy.get('input').type('202206')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('転職予定月').should('be.visible')
+          cy.get('input').type('202303')
+          cy.contains('つぎの質問へ').click()
+
+          cy.contains('まえの質問へ').click()
+          cy.contains('転職予定月').should('be.visible')
+
+          cy.contains('まえの質問へ').click()
+          cy.contains('退職予定月').should('be.visible')
+
+          cy.contains('つぎの質問へ').click()
+          cy.contains('転職予定月').should('be.visible')
+
+          cy.visit('/simulations/new/salary')
+          cy.contains('転職予定月').should('be.visible')
+        })
+      })
+
+      context('when current page is NOT simulations/new/*', () => {
+        it('should redirect first step of simulation', () => {
+          cy.visit('/')
+          cy.contains('いますぐ計算する').click()
+          cy.contains('退職予定月').should('be.visible')
+
+          cy.visit('/simulations/new/age')
+          cy.contains('退職予定月').should('be.visible')
+        })
+      })
+    }
+  )
 })


### PR DESCRIPTION
遷移を禁止するのは以下のケース

- 最終ステップ未到達で/simulationsへアクセスするケース
- 一つ前の質問が未回答の状態で直接simulations/new/*にアクセスするケース

いずれの場合も、直近に開いていたステップ（シミュレーション以外の画面の場合は最初のステップ）に遷移する
一番先頭のステップに遷移することも考えたが、どこに遷移したかわかりにくいのでこのような仕様になっている

Closes: #215

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
