### PR TITLE
レスポンシブデザインに対応

### DIFF
--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -1,13 +1,13 @@
 <template>
-  <form class="mt-20" @submit="onSubmit">
+  <form @submit="onSubmit">
     <div class="flex">
       <ProgressStep :top="current + 1" :bottom="steps" />
       <ProgressBar :top="current" :bottom="steps - 1" />
     </div>
-    <div class="h-80 px-24 m-12 text-center">
+    <div class="h-96 px-4 md:px-24 pt-12 text-center">
       <router-view></router-view>
     </div>
-    <div class="flex px-24 justify-evenly">
+    <div class="md:w-9/12 md:mx-auto mt-16 flex px-4 justify-evenly">
       <button class="prev-button" v-if="prev" type="button" @click="goToPrev">
         まえの質問へ
       </button>
@@ -66,15 +66,35 @@ const goToPrev = () => {
 </script>
 
 <style scope>
+.form-label {
+  @apply h-20 md:h-24 text-xl md:text-4xl inline-block mb-8 md:mb-4;
+}
+
+.form-field {
+  @apply px-6 py-2 md:w-9/12 rounded-md border-4 border-boundaryBlack focus:border-primary tracking-widest text-2xl md:text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
+}
+
+.form-field-error {
+  @apply px-6 py-2 md:w-9/12 rounded-md border-4 border-red-500 focus:border-red-600 tracking-widest text-2xl md:text-5xl outline-none leading-8 placeholder-boundaryBlack;
+}
+
+.form-tips {
+  @apply mt-2 text-xs md:text-sm text-gray;
+}
+
+.form-error {
+  @apply flex md:w-9/12 md:mx-auto h-6 justify-end text-red-500 text-xs md:text-base;
+}
+
 .next-button {
-  @apply flex justify-between items-center bg-primary text-white rounded-full text-lg w-52 px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray;
+  @apply flex justify-between items-center bg-primary text-white rounded-full text-sm md:text-lg w-40 md:w-52 px-5 md:px-8 py-3 md:py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary after:content-[''] after:w-2 md:after:w-3 after:h-2 md:after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray;
 }
 
 .submit-button {
-  @apply flex justify-evenly items-center bg-accent text-white rounded-full text-lg w-52 px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-accent after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray;
+  @apply flex justify-evenly items-center bg-accent text-white rounded-full text-sm md:text-lg w-40 md:w-52 px-5 md:px-8 py-3 md:py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-accent after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray;
 }
 
 .prev-button {
-  @apply flex justify-between items-center bg-secondary text-gray rounded-full text-lg w-52 px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-secondary before:content-[''] before:w-3 before:h-3 before:rotate-45 before:border-solid before:border-gray before:border-b-4 before:border-l-4 before:hover:border-gray;
+  @apply flex justify-between items-center bg-secondary text-gray rounded-full text-sm md:text-lg w-40 md:w-52 px-5 md:px-8 py-3 md:py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-secondary before:content-[''] before:w-2 md:before:w-3 before:h-2 md:before:h-3 before:rotate-45 before:border-solid before:border-gray before:border-b-4 before:border-l-4 before:hover:border-gray;
 }
 </style>

--- a/app/javascript/src/components/Home.vue
+++ b/app/javascript/src/components/Home.vue
@@ -33,7 +33,7 @@
           >
             準備するもの（なくてもOK！）
           </h2>
-          <p class="text-sm text-center text-gray">
+          <p class="text-xs md:text-sm text-center text-gray">
             <i class="fas fa-info-circle mr-1"></i>
             額面の年収がだいたいいくらかわかれば計算できます！
           </p>

--- a/app/javascript/src/components/ProgressBar.vue
+++ b/app/javascript/src/components/ProgressBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="grow mx-32 flex justify-center items-center">
+  <div class="grow mx-4 md:mx-32 flex justify-center items-center">
     <div class="w-full bg-secondary rounded-full">
       <div
         v-if="progress"

--- a/app/javascript/src/components/ProgressStep.vue
+++ b/app/javascript/src/components/ProgressStep.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <span class="text-6xl text-primary">{{ progress }}</span>
-    <span class="text-3xl font-semi-bold text-gray"> / </span>
-    <span class="text-4xl text-primary">{{ steps }}</span>
+    <span class="text-3xl md:text-6xl text-primary">{{ progress }}</span>
+    <span class="text-base md:text-3xl text-gray"> / </span>
+    <span class="text-2xl md:text-4xl text-primary">{{ steps }}</span>
   </div>
 </template>
 

--- a/app/javascript/src/components/SimulationForm.vue
+++ b/app/javascript/src/components/SimulationForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container mx-auto">
-    <div class="px-4 pt-16">
+    <div class="px-4 pt-16 mb-8">
       <FormWizard @submit="onSubmit" />
     </div>
   </div>
@@ -12,5 +12,5 @@ import { useRouter } from 'vue-router'
 
 const router = useRouter()
 
-const onSubmit = () => router.push('/simulations')
+const onSubmit = () => router.push({ name: 'Result' })
 </script>

--- a/app/javascript/src/components/SimulationForm.vue
+++ b/app/javascript/src/components/SimulationForm.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="container mx-auto">
-    <FormWizard @submit="onSubmit" />
+    <div class="px-4 pt-16">
+      <FormWizard @submit="onSubmit" />
+    </div>
   </div>
 </template>
 
@@ -12,29 +14,3 @@ const router = useRouter()
 
 const onSubmit = () => router.push('/simulations')
 </script>
-
-<style scope>
-.form-label {
-  @apply h-24 text-4xl inline-block mb-2;
-}
-
-.form-field {
-  @apply px-6 py-2 w-9/12 rounded-md border-4 border-boundaryBlack focus:border-primary tracking-widest text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
-}
-
-.form-field-error {
-  @apply px-6 py-2 w-9/12 rounded-md border-4 border-red-500 focus:border-red-600 tracking-widest text-5xl outline-none leading-8 placeholder-boundaryBlack;
-}
-
-.form-tips {
-  @apply mt-2 text-sm text-gray;
-}
-
-.form-error {
-  @apply flex h-6 justify-center text-red-500 mb-2;
-}
-
-.form-supplement {
-  @apply pl-4 text-4xl text-black;
-}
-</style>

--- a/app/javascript/src/components/SimulationResult.vue
+++ b/app/javascript/src/components/SimulationResult.vue
@@ -1,87 +1,98 @@
 <template>
   <LoadingAnimation v-if="loading" />
   <div v-else>
-    <div class="max-w-screen-lg mx-auto pt-32 text-center">
-      <div class="mb-6 mx-32">
-        <p class="text-3xl">
-          {{ formatDate(result.retirement_month) }}に退職して、{{
-            formatDate(result.employment_month)
-          }}に就職すると...
+    <div class="md:max-w-screen-lg md:mx-auto pt-12 md:pt-32 text-center">
+      <div class="flex md:flex-row md:justify-center flex-col mb-6">
+        <p class="text-lg md:text-3xl">
+          {{ formatDate(result.retirement_month) }}に退職して、
+        </p>
+        <p class="text-lg md:text-3xl">
+          {{ formatDate(result.employment_month) }}に就職すると...
         </p>
       </div>
-      <div class="mb-10 mx-42">
+      <div
+        class="flex md:flex-row md:justify-center md:items-end gap-8 md:gap-2 flex-col mb-10 md:mx-42"
+      >
         <p>
           <span>約</span>
-          <span class="mx-6">
-            <span class="text-8xl text-primary">{{
+          <span class="mx-4">
+            <span class="text-6xl md:text-8xl text-primary">{{
               formatAmount(result.grand_total)
             }}</span>
-            <span class="text-3xl text-primary ml-2">円</span>
+            <span class="text-base md:text-3xl text-primary ml-2">円</span>
           </span>
-          <span>かかります</span>
         </p>
+        <p>かかります</p>
       </div>
-      <div class="mb-20 mx-72 flex justify-between">
-        <div class="flex-1">
+      <div
+        class="mb-8 md:mb-20 md:justify-center flex md:flex-row flex-col md:gap-x-4 items-start md:px-56 px-24"
+      >
+        <div
+          class="flex flex-row justify-between items-center md:flex-col gap-y-2 md:basis-full w-full"
+        >
           <p
-            class="text-sm underline underline-offset-2 decoration-4 decoration-primary"
+            class="text-xs md:text-sm underline underline-offset-2 decoration-4 decoration-primary"
           >
             国民健康保険
           </p>
-          <p class="text-xl mt-2">
+          <p class="text-lg md:text-xl">
             {{ formatAmount(result.sub_total.insurance) }}円
           </p>
         </div>
-        <div class="flex-1">
+        <div
+          class="flex flex-row justify-between items-center md:flex-col gap-y-2 md:basis-full w-full"
+        >
           <p
-            class="text-sm underline underline-offset-2 decoration-4 decoration-red-600"
+            class="text-xs md:text-sm underline underline-offset-2 decoration-4 decoration-red-600"
           >
             国民年金
           </p>
-          <p class="text-xl mt-2">
+          <p class="text-lg md:text-xl">
             {{ formatAmount(result.sub_total.pension) }}円
           </p>
         </div>
-        <div class="flex-1">
+        <div
+          class="flex flex-row justify-between items-center md:flex-col gap-y-2 md:basis-full w-full"
+        >
           <p
-            class="text-sm underline underline-offset-2 decoration-4 decoration-yellow-500"
+            class="text-xs md:text-sm underline underline-offset-2 decoration-4 decoration-yellow-500"
           >
             住民税
           </p>
-          <p class="text-xl mt-2">
+          <p class="text-lg md:text-xl">
             {{ formatAmount(result.sub_total.residence) }}円
           </p>
         </div>
       </div>
-      <div class="flex flex-wrap justify-around mb-52 mx-52">
+      <div class="flex flex-wrap justify-around mb-8 md:mb-52 md:px-32">
         <button
-          class="text-lg w-64 flex justify-between items-center bg-primary text-white rounded-full px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary before:content-[''] before:w-3 before:h-3 before:rotate-45 before:border-solid before:border-white before:border-b-4 before:border-l-4 before:hover:border-gray"
+          class="text-sm md:text-lg w-52 md:w-64 flex justify-between items-center bg-primary text-white rounded-full px-6 md:px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary before:content-[''] before:w-2 md:before:w-3 before:h-2 md:before:h-3 before:rotate-45 before:border-solid before:border-white before:border-b-4 before:border-l-4 before:hover:border-gray"
           @click="moveForm"
         >
           もういちど計算する
         </button>
         <button
-          class="text-lg w-60 flex justify-evenly items-center bg-accent text-white rounded-full px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-accent after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray"
+          class="hidden md:flex text-lg w-60 flex justify-evenly items-center bg-accent text-white rounded-full px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-accent after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray"
           @click="scrollDetail"
         >
           詳細をみる
         </button>
       </div>
     </div>
-    <div class="bg-secondary py-12" id="detail">
-      <div class="max-w-screen-lg mx-auto p-12">
+    <div class="bg-secondary py-4 md:py-12" id="detail">
+      <div class="md:max-w-screen-lg md:mx-auto p-4 md:p-12">
         <h2
-          class="text-center text-3xl mb-12 underline underline-offset-8 decoration-4 decoration-primary"
+          class="text-center text-xl md:text-3xl mb-12 underline underline-offset-8 decoration-4 decoration-primary"
         >
           個人負担額の詳細
         </h2>
         <div
           v-for="monthly_payment in result.monthly_payment"
           :key="monthly_payment.month"
-          class="px-8 py-8 mb-4 last:mb-0 shadow-md bg-white rounded-xl"
+          class="px-6 md:px-8 py-5 md:py-8 mb-4 last:mb-0 shadow-md bg-white rounded-xl"
         >
           <div class="separator">
-            <p class="text-xl">
+            <p class="text-lg md:text-xl">
               {{ formatDate(monthly_payment.month) }}
             </p>
           </div>
@@ -106,9 +117,9 @@
           </div>
         </div>
       </div>
-      <div class="flex justify-center">
+      <div class="flex justify-center my-4">
         <button
-          class="w-52 flex justify-evenly items-center bg-primary text-white rounded-full px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-l-4 after:border-t-4 after:hover:border-gray"
+          class="text-sm md:text-lg w-48 md:w-52 flex justify-evenly items-center bg-primary text-white rounded-full px-4 md:px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary after:content-[''] after:w-2 after:h-2 md:after:w-3 md:after:h-3 after:rotate-45 after:border-solid after:border-white after:border-l-4 after:border-t-4 after:hover:border-gray"
           @click="scrollTop"
         >
           ページ上部へ

--- a/app/javascript/src/components/simulation_form/Age.vue
+++ b/app/javascript/src/components/simulation_form/Age.vue
@@ -1,8 +1,6 @@
 <template>
   <label for="age" class="form-label">年齢を教えてください</label>
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error }}</span>
-  </p>
+  <p class="form-error">{{ error }}</p>
   <input
     id="age"
     class="form-field text-right"
@@ -11,7 +9,7 @@
     :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
     placeholder="30"
-  /><span class="form-supplement">歳</span>
+  />
 </template>
 
 <script setup>

--- a/app/javascript/src/components/simulation_form/EmploymentMonth.vue
+++ b/app/javascript/src/components/simulation_form/EmploymentMonth.vue
@@ -2,9 +2,7 @@
   <label for="employmentMonth" class="form-label"
     >転職予定月を教えてください</label
   >
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error }}</span>
-  </p>
+  <p class="form-error">{{ error }}</p>
   <input
     id="employmentMonth"
     class="form-field text-center"

--- a/app/javascript/src/components/simulation_form/InsuranceCompleteButton.vue
+++ b/app/javascript/src/components/simulation_form/InsuranceCompleteButton.vue
@@ -1,12 +1,12 @@
 <template>
   <button
     type="button"
-    class="border-0 w-48 p-3 focus:outline-none rounded-full text-sm bg-accent text-white hover:opacity-80 shadow-xl group relative cursor-pointer"
+    class="border-0 w-40 md:w-48 p-3 focus:outline-none rounded-full text-xs md:text-sm bg-accent text-white hover:opacity-80 shadow-xl group relative cursor-pointer"
     data-test-id="completeInsuranceButton"
     @click="completeInsurance"
   >
     <span
-      class="group-hover:opacity-100 group-hover:visible invisible opacity-0 absolute left-1/2 -translate-x-1/2 inline-block px-4 py-2 -bottom-12 whitespace-nowrap text-xs leading-tight bg-gray text-white rounded-xl ease-in duration-200 before:content-[''] before:absolute before:left-1/2 before:-top-3 before:-ml-2 before:border-8 before:border-solid before:border-transparent before:border-b-8 before:border-b-gray"
+      class="group-hover:opacity-100 group-hover:visible invisible opacity-0 absolute left-1/2 -translate-x-1/2 inline-block px-4 py-2 -bottom-10 md:-bottom-12 whitespace-nowrap text-xs leading-tight bg-gray text-white rounded-xl ease-in duration-200 before:content-[''] before:absolute before:left-1/2 before:-top-3 before:-ml-2 before:border-8 before:border-solid before:border-transparent before:border-b-8 before:border-b-gray"
       >{{ tooltipText }}</span
     >
     <i class="fas fa-robot mr-2"></i>おまかせで入力する

--- a/app/javascript/src/components/simulation_form/PostalCode.vue
+++ b/app/javascript/src/components/simulation_form/PostalCode.vue
@@ -1,10 +1,8 @@
 <template>
-  <label for="postalCode" class="form-label whitespace-nowrap">
+  <label for="postalCode" class="form-label">
     お住まいの地域の郵便番号を教えてください
   </label>
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error || addressError }}</span>
-  </p>
+  <p class="form-error">{{ error || addressError }}</p>
   <input
     id="postalCode"
     class="form-field text-center"

--- a/app/javascript/src/components/simulation_form/PreviousSalary.vue
+++ b/app/javascript/src/components/simulation_form/PreviousSalary.vue
@@ -3,9 +3,7 @@
     <span class="inline-block">{{ `昨昨年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「所得額」を教えてください</span>
   </label>
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error }}</span>
-  </p>
+  <p class="form-error">{{ error }}</p>
   <input
     id="previousSalary"
     class="form-field text-right"

--- a/app/javascript/src/components/simulation_form/PreviousSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/PreviousSocialInsurance.vue
@@ -3,9 +3,7 @@
     <span class="inline-block">{{ `昨年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「社会保険料」を教えてください</span>
   </label>
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error }}</span>
-  </p>
+  <p class="form-error">{{ error }}</p>
   <input
     id="previousSocialInsurance"
     class="form-field text-right"

--- a/app/javascript/src/components/simulation_form/RetirementMonth.vue
+++ b/app/javascript/src/components/simulation_form/RetirementMonth.vue
@@ -2,9 +2,7 @@
   <label for="retirementMonth" class="form-label"
     >退職予定月を教えてください</label
   >
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error }}</span>
-  </p>
+  <p class="form-error">{{ error }}</p>
   <input
     id="retirementMonth"
     class="text-center"

--- a/app/javascript/src/components/simulation_form/Salary.vue
+++ b/app/javascript/src/components/simulation_form/Salary.vue
@@ -3,9 +3,7 @@
     <span class="inline-block">{{ `昨年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「所得額」を教えてください</span>
   </label>
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error }}</span>
-  </p>
+  <p class="form-error">{{ error }}</p>
   <input
     id="salary"
     class="form-field text-right"

--- a/app/javascript/src/components/simulation_form/ScheduledSalary.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSalary.vue
@@ -3,9 +3,7 @@
     <span class="inline-block">{{ `今年度（${from} ~ ${to}）` }}の</span
     ><span class="inline-block">「所得額」を教えてください</span>
   </label>
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error }}</span>
-  </p>
+  <p class="form-error">{{ error }}</p>
   <input
     id="scheduledSalary"
     class="form-field text-right"

--- a/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/ScheduledSocialInsurance.vue
@@ -3,9 +3,7 @@
     <span class="inline-block">{{ `今年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「社会保険料」を教えてください</span>
   </label>
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error }}</span>
-  </p>
+  <p class="form-error">{{ error }}</p>
   <input
     id="scheduledSalary"
     class="form-field text-right"

--- a/app/javascript/src/components/simulation_form/SocialInsurance.vue
+++ b/app/javascript/src/components/simulation_form/SocialInsurance.vue
@@ -3,9 +3,7 @@
     <span class="inline-block">{{ `昨年度（${from} ~ ${to}）の` }}</span
     ><span class="inline-block">「社会保険料」を教えてください</span>
   </label>
-  <p class="mb-1 w-9/12 mx-auto text-right">
-    <span class="ml-2 text-red-600">{{ error }}</span>
-  </p>
+  <p class="form-error">{{ error }}</p>
   <input
     id="socialInsurance"
     class="text-right"

--- a/app/javascript/src/store/simulation.js
+++ b/app/javascript/src/store/simulation.js
@@ -150,7 +150,7 @@ export default function simulationStore() {
     },
 
     get isFinished() {
-      return state.value.steps === state.value.currentStepIdx + 1
+      return state.value.routes.length === state.value.currentStep + 1
     },
 
     get accessibleRoute() {


### PR DESCRIPTION
Closes: #134 

## やったこと

- レスポンシブデザインに対応
- シミュレーション画面へのルート遷移が正しくない条件であったため、修正

## UIの変更

### シミュレーション画面

![CleanShot 2022-03-28 at 21 01 31](https://user-images.githubusercontent.com/61409641/160393665-28aa7c8d-bd8b-49a0-8652-7487eafcd875.png)


### 結果画面

![CleanShot 2022-03-28 at 21 01 05](https://user-images.githubusercontent.com/61409641/160393591-ac67f87b-d7b4-40a2-9e15-ee971cd9acd0.png)

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
