### PR TITLE
郵便番号が初期表示でエラーにならないように修正

### DIFF
--- a/app/javascript/src/components/simulation_form/PostalCode.vue
+++ b/app/javascript/src/components/simulation_form/PostalCode.vue
@@ -37,7 +37,7 @@ let {
 let { value: address, errorMessage: addressError } = useField('address')
 
 watchEffect(async () => {
-  address.value = ''
+  if (!params.postalCode && !postalCode.value) return
 
   if (!postalCode.value) return
   const zipCode = postalCode.value.replace(/[^\d]+/g, '')
@@ -53,7 +53,7 @@ watchEffect(async () => {
     if (!code) {
       address.value = `${pref} ${city}`
     } else {
-      return
+      address.value = ''
     }
   } catch (err) {
     console.warn(err)


### PR DESCRIPTION
## やったこと

（変更前）初期表示の状態でも、住所がないエラーメッセージが表示されてしまう
（変更後）初期表示の場合は、エラーを表示しないように修正

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
