### PR TITLE
Heroku用の設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,12 @@ COPY Gemfile.lock /quitcost/Gemfile.lock
 RUN gem install bundler -v '2.2.31'
 RUN bundle install
 
+COPY package.json /quitcost/package.json
+COPY yarn.lock  /quitcost/yarn.lock
+RUN yarn install
+
 COPY . /quitcost
+# Compile assets
+RUN if [ "$RAILS_ENV" = "production" ]; then SECRET_KEY_BASE=$(rake secret) bundle exec rake assets:precompile; fi
+
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM ruby:3.0.3
+ARG RAILS_ENV
+ENV RAILS_ENV=$RAILS_ENV
 
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ruby:3.0.3
 ARG RAILS_ENV
+ARG RAILS_SERVE_STATIC_FILES
 ENV RAILS_ENV=$RAILS_ENV
+ENV RAILS_SERVE_STATIC_FILES=$RAILS_SERVE_STATIC_FILES
 
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.hosts << "quitcost.herokuapp.com"
 end

--- a/heroku.yml
+++ b/heroku.yml
@@ -7,5 +7,6 @@ build:
     web: Dockerfile
   config:
     RAILS_ENV: production
+    RAILS_SERVE_STATIC_FILES: enabled
 run:
   web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
## 概要

Herokuへのデプロイ用の設定を追加する。
HerokuへのデプロイにはContainerRegistryを使用する形式とheroku.ymlを使用する形式があるが、構成管理をコードで行えるため後者の方法を採用する。

これを実現するためにDockerfile側でのビルド設定の追加と、heroku.ymlによる構成管理の追加を実施する。

## やったこと

- heroku.ymlを追加
- Dockerfileでassets:precompileを行うように指定
- Blocked_hostの設定に、自身のHerokuアプリを許可するように設定

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
