### PR TITLE
モバイルでのフォームの横幅が画面に収まるように修正

### DIFF
--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -7,7 +7,7 @@
     <div class="h-96 px-4 md:px-24 pt-12 text-center">
       <router-view></router-view>
     </div>
-    <div class="md:w-9/12 md:mx-auto mt-16 flex px-4 justify-evenly">
+    <div class="md:w-9/12 md:mx-auto mt-16 flex px-4 justify-evenly gap-x-4">
       <button class="prev-button" v-if="prev" type="button" @click="goToPrev">
         まえの質問へ
       </button>
@@ -71,7 +71,7 @@ const goToPrev = () => {
 }
 
 .form-field {
-  @apply px-6 py-2 md:w-9/12 rounded-md border-4 border-boundaryBlack focus:border-primary tracking-widest text-2xl md:text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
+  @apply md:px-6 py-2 md:w-9/12 rounded-md border-4 border-boundaryBlack focus:border-primary tracking-widest text-2xl md:text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
 }
 
 .form-field-error {


### PR DESCRIPTION
小さい画面だとフォームが横に広がってしまう点と、ボタンがくっつきすぎる点を修正しました。
（実際の画面でみておかしかったらもう一度修正します）

## UIの変更

### 変更前

![CleanShot 2022-04-01 at 17 41 34](https://user-images.githubusercontent.com/61409641/161228065-0a45ab9a-cf2b-475d-9f35-b65b56423ce9.png)


### 変更後

![CleanShot 2022-04-01 at 17 40 55](https://user-images.githubusercontent.com/61409641/161227946-4f63f2ce-7561-4eba-b072-4b80e2e309a5.png)


---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
