### PR TITLE
build(heroku): release phaseでdbのマイグレーションを行うように変更

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -9,6 +9,7 @@ build:
     RAILS_ENV: production
     RAILS_SERVE_STATIC_FILES: enabled
 release:
+  image: web
   command:
     - rake db:migrate
 run:


### PR DESCRIPTION
#255 でimageの記述がなかったため、Heroku側でデプロイが失敗していた

```
=== Fetching app code
=!= Couldn't find the release image configured for this app. Is there a matching run process?
```
そのため、コマンドを実行するイメージを指定する


---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
