### PR TITLE
chore: Gem:JpLocalGovをリポジトリではなく、RubyGemsから取得するよう変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise'
 gem 'devise-i18n'
 gem 'fiscali'
+gem 'jp_local_gov'
 gem 'kaminari'
 gem 'meta-tags'
 gem 'rails-i18n'
@@ -71,5 +72,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-
-gem 'jp_local_gov', github: 'IkumaTadokoro/jp_local_gov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/IkumaTadokoro/jp_local_gov.git
-  revision: 7a46d153dd17fd04d28e98e417e6647f58adec41
-  specs:
-    jp_local_gov (0.2.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -115,6 +109,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jp_local_gov (0.3.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -330,7 +325,7 @@ DEPENDENCIES
   fiscali
   html2slim
   jbuilder (~> 2.7)
-  jp_local_gov!
+  jp_local_gov
   kaminari
   letter_opener_web
   listen (~> 3.3)


### PR DESCRIPTION
開発中はGemのリリースが行われないケースを考慮してリポジトリを参照していたが、
現時点で最新版がリリースされているため考慮が不要になった

Closes: #248

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
