### PR TITLE
fix(Simulation): モバイルだとフォームが崩れるのを修正（たぶん）

### DIFF
--- a/app/javascript/src/components/FormWizard.vue
+++ b/app/javascript/src/components/FormWizard.vue
@@ -71,11 +71,11 @@ const goToPrev = () => {
 }
 
 .form-field {
-  @apply md:px-6 py-2 md:w-9/12 rounded-md border-4 border-boundaryBlack focus:border-primary tracking-widest text-2xl md:text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
+  @apply w-full md:px-6 py-2 md:w-9/12 rounded-md border-4 border-boundaryBlack focus:border-primary tracking-widest text-2xl md:text-5xl outline-none leading-8 transition-colors duration-200 ease-in-out placeholder-boundaryBlack;
 }
 
 .form-field-error {
-  @apply px-6 py-2 md:w-9/12 rounded-md border-4 border-red-500 focus:border-red-600 tracking-widest text-2xl md:text-5xl outline-none leading-8 placeholder-boundaryBlack;
+  @apply w-full md:px-6 py-2 md:w-9/12 rounded-md border-4 border-red-500 focus:border-red-600 tracking-widest text-2xl md:text-5xl outline-none leading-8 placeholder-boundaryBlack;
 }
 
 .form-tips {


### PR DESCRIPTION
width: 100%を指定することで広がりを抑制できるようになったと思うんですが、実機確認してみないとわからんです。
→このブランチの内容でデプロイして実機確認し、問題ないことを確認できました。

Closes: #262

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
