### PR TITLE
API::Simulationsのリクエストパラメータに対してバリデーションを追加

### DIFF
--- a/app/controllers/api/simulations_controller.rb
+++ b/app/controllers/api/simulations_controller.rb
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
 
 class API::SimulationsController < ApplicationController
+  before_action :validate_parameter, only: :show
+
   def show
-    @simulation = Simulation.new(simulation_params)
+    @simulation = Simulation.new(parameter)
   end
 
   private
+
+  def validate_parameter
+    return if parameter.valid?
+
+    render json: { 'errors': parameter.errors.full_messages }, status: :bad_request
+  end
+
+  def parameter
+    @parameter ||= Simulation::Parameter.new(simulation_params)
+  end
 
   def simulation_params
     params.permit(

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -3,8 +3,8 @@
 class Simulation
   CATEGORY = %i[insurance pension residence].freeze
 
-  def initialize(params)
-    @parameter = Parameter.new(params)
+  def initialize(parameter)
+    @parameter = parameter
   end
 
   def grand_total

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -7,7 +7,7 @@ class Simulation
   CATEGORY = %i[insurance pension residence].freeze
 
   def initialize(params)
-    @param_parser = ParamParser.new(params)
+    @parameter = Parameter.new(params)
   end
 
   def grand_total
@@ -26,26 +26,26 @@ class Simulation
   end
 
   def retirement_month
-    @param_parser.retirement_month
+    @parameter.retirement_month
   end
 
   def employment_month
-    @param_parser.employment_month
+    @parameter.employment_month
   end
 
   private
 
-  attr_reader :param_parser
+  attr_reader :parameter
 
   def insurance
-    Simulation::Insurance.calc(param_parser)
+    Simulation::Insurance.calc(parameter)
   end
 
   def pension
-    Simulation::Pension.calc(param_parser)
+    Simulation::Pension.calc(parameter)
   end
 
   def residence
-    Simulation::Residence.calc(param_parser)
+    Simulation::Residence.calc(parameter)
   end
 end

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class Simulation
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
   CATEGORY = %i[insurance pension residence].freeze
 
   def initialize(params)

--- a/app/models/simulation/insurance.rb
+++ b/app/models/simulation/insurance.rb
@@ -3,16 +3,16 @@
 class Simulation::Insurance
   include MonthIterable
 
-  def self.calc(param_parser)
-    new(param_parser).calc
+  def self.calc(parameter)
+    new(parameter).calc
   end
 
-  def initialize(param_parser)
-    @from = param_parser.retirement_month
-    @to = param_parser.employment_month
-    @local_gov_code = param_parser.local_gov_code
-    @age = param_parser.age
-    @salary_table = param_parser.salary_table
+  def initialize(parameter)
+    @from = parameter.retirement_month
+    @to = parameter.employment_month
+    @local_gov_code = parameter.local_gov_code
+    @age = parameter.age
+    @salary_table = parameter.salary_table
   end
 
   def calc

--- a/app/models/simulation/parameter.rb
+++ b/app/models/simulation/parameter.rb
@@ -1,42 +1,62 @@
 # frozen_string_literal: true
 
 class Simulation::Parameter
-  attr_reader :retirement_month, :employment_month, :prefecture, :city, :age, :local_gov_code, :salary_table, :social_insurance_table
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_reader :local_gov_code, :salary_table, :social_insurance_table
+
+  attribute :simulation_date, :time
+  attribute :retirement_month, :time
+  attribute :employment_month, :time
+  attribute :prefecture, :string
+  attribute :city, :string
+  attribute :age, :integer
+  attribute :previous_salary, :integer
+  attribute :previous_social_insurance, :integer
+  attribute :salary, :integer
+  attribute :social_insurance, :integer
+  attribute :scheduled_salary, :integer
+  attribute :scheduled_social_insurance, :integer
 
   def initialize(params)
-    @retirement_month = Time.zone.parse(params[:retirement_month])
-    @employment_month = Time.zone.parse(params[:employment_month])
-    @age = params[:age].to_i
-    @local_gov_code = build_local_gov_code(params)
-    @salary_table = build_salary_table(params)
-    @social_insurance_table = build_social_insurance_table(params)
+    super(parse_dates!(params))
+    @local_gov_code = build_local_gov_code
+    @salary_table = build_salary_table
+    @social_insurance_table = build_social_insurance_table
   end
 
   private
 
-  def build_local_gov_code(params)
-    JpLocalGov.where(prefecture: params[:prefecture], city: params[:city]).first.code
+  # ActiveSupport::TimeWithZoneを前提にした処理設計になっているが、
+  # ActiveModel::Attributesの型キャストにサポートがないため、型キャストが実行される前に一度変換を実施する
+  def parse_dates!(params)
+    date_attributes = %i[simulation_date retirement_month employment_month]
+    date_attributes.each { |attribute| params[attribute] = Time.zone.parse(params[attribute]) }
+    params
   end
 
-  def build_salary_table(params)
-    base_fiscal_year = base_fiscal_year(params)
+  def build_local_gov_code
+    JpLocalGov.where(prefecture: prefecture, city: city).first.code
+  end
+
+  def build_salary_table
     {
-      base_fiscal_year.pred => params[:previous_salary].to_i || 0,
-      base_fiscal_year => params[:salary].to_i || 0,
-      base_fiscal_year.next => params[:scheduled_salary].to_i || 0
+      base_fiscal_year.pred => previous_salary,
+      base_fiscal_year => salary,
+      base_fiscal_year.next => scheduled_salary
     }
   end
 
-  def build_social_insurance_table(params)
-    base_fiscal_year = base_fiscal_year(params)
+  def build_social_insurance_table
     {
-      base_fiscal_year.pred => params[:previous_social_insurance].to_i || 0,
-      base_fiscal_year => params[:social_insurance].to_i || 0,
-      base_fiscal_year.next => params[:scheduled_social_insurance].to_i || 0
+      base_fiscal_year.pred => previous_social_insurance,
+      base_fiscal_year => social_insurance,
+      base_fiscal_year.next => scheduled_social_insurance
     }
   end
 
-  def base_fiscal_year(params)
-    Time.zone.parse(params[:simulation_date]).financial_year
+  def base_fiscal_year
+    simulation_date.financial_year
   end
 end

--- a/app/models/simulation/parameter.rb
+++ b/app/models/simulation/parameter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Simulation::ParamParser
+class Simulation::Parameter
   attr_reader :retirement_month, :employment_month, :prefecture, :city, :age, :local_gov_code, :salary_table, :social_insurance_table
 
   def initialize(params)

--- a/app/models/simulation/parameter.rb
+++ b/app/models/simulation/parameter.rb
@@ -26,6 +26,21 @@ class Simulation::Parameter
     @social_insurance_table = build_social_insurance_table
   end
 
+  with_options presence: true do
+    validates :retirement_month
+    validates :employment_month
+    validates :local_gov_code
+    validates :age
+  end
+
+  validates :age, numericality: { greater_than_or_equal_to: 0 }
+  validates :retirement_month, comparison: { greater_than: :simulation_date }
+  validates :employment_month, comparison: { greater_than: :retirement_month }
+  validates :previous_salary, comparison: { greater_than_or_equal_to: :previous_social_insurance }
+  validates :salary, comparison: { greater_than: :social_insurance }
+  validates :scheduled_salary, comparison: { greater_than_or_equal_to: :scheduled_social_insurance }
+  validates_with RequiredSalaryAndSocialInsuranceValidator
+
   private
 
   # ActiveSupport::TimeWithZoneを前提にした処理設計になっているが、

--- a/app/models/simulation/pension.rb
+++ b/app/models/simulation/pension.rb
@@ -3,13 +3,13 @@
 class Simulation::Pension
   include MonthIterable
 
-  def self.calc(param_parser)
-    new(param_parser).call
+  def self.calc(parameter)
+    new(parameter).call
   end
 
-  def initialize(param_parser)
-    @from = param_parser.retirement_month
-    @to = param_parser.employment_month
+  def initialize(parameter)
+    @from = parameter.retirement_month
+    @to = parameter.employment_month
   end
 
   def call

--- a/app/models/simulation/residence.rb
+++ b/app/models/simulation/residence.rb
@@ -15,15 +15,15 @@ class Simulation::Residence
   SPECIAL_COLLECTION_DUES = (1..12).to_a.freeze
   NON_TAXABLE_SALARY_LIMIT = 1_000_000
 
-  def self.calc(param_parser)
-    new(param_parser).calc
+  def self.calc(parameter)
+    new(parameter).calc
   end
 
-  def initialize(param_parser)
-    @from = param_parser.retirement_month
-    @to = param_parser.employment_month
-    @salary_table = param_parser.salary_table
-    @social_insurance_table = param_parser.social_insurance_table
+  def initialize(parameter)
+    @from = parameter.retirement_month
+    @to = parameter.employment_month
+    @salary_table = parameter.salary_table
+    @social_insurance_table = parameter.social_insurance_table
   end
 
   def calc

--- a/app/validators/required_salary_and_social_insurance_validator.rb
+++ b/app/validators/required_salary_and_social_insurance_validator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class RequiredSalaryAndSocialInsuranceValidator < ActiveModel::Validator
+  def validate(record)
+    targets = []
+    targets.push(:previous_salary, :previous_social_insurance) if require_previous?(record)
+    targets.push(:salary, :social_insurance) if require_current?(record)
+    targets.push(:scheduled_salary, :scheduled_social_insurance) if require_scheduled?(record)
+
+    targets.each { |target| record.errors.add(target, 'は必須です') if record.send(target).nil? }
+  end
+
+  private
+
+  def require_previous?(record)
+    record.retirement_month < record.simulation_date.beginning_of_financial_year.advance(months: 2)
+  end
+
+  def require_current?(record)
+    record.retirement_month < record.simulation_date.beginning_of_financial_year.advance(months: 2, years: 1)
+  end
+
+  def require_scheduled?(record)
+    record.employment_month >= record.simulation_date.beginning_of_financial_year.advance(years: 1)
+  end
+end

--- a/spec/models/simulation/insurance_spec.rb
+++ b/spec/models/simulation/insurance_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Insurance, type: :model do
   describe '.calc' do
-    subject { Simulation::Insurance.calc(param_parser) }
-    let(:param_parser) do
-      Simulation::ParamParser.new(
+    subject { Simulation::Insurance.calc(parameter) }
+    let(:parameter) do
+      Simulation::Parameter.new(
         {
           retirement_month: retirement_month,
           employment_month: employment_month,

--- a/spec/models/simulation/parameter_spec.rb
+++ b/spec/models/simulation/parameter_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Simulation::ParamParser' do
+RSpec.describe 'Simulation::Parameter' do
   describe '#salary_table' do
-    subject { Simulation::ParamParser.new(params).salary_table }
+    subject { Simulation::Parameter.new(params).salary_table }
     let!(:params) do
       {
         retirement_month: '2022-06-01',
@@ -34,7 +34,7 @@ RSpec.describe 'Simulation::ParamParser' do
   end
 
   describe '#social_insurance_table' do
-    subject { Simulation::ParamParser.new(params).social_insurance_table }
+    subject { Simulation::Parameter.new(params).social_insurance_table }
     let!(:params) do
       {
         retirement_month: '2022-06-01',

--- a/spec/models/simulation/pension_spec.rb
+++ b/spec/models/simulation/pension_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Pension, type: :model do
   describe '.calc' do
-    subject { Simulation::Pension.calc(param_parser) }
-    let(:param_parser) do
-      Simulation::ParamParser.new(
+    subject { Simulation::Pension.calc(parameter) }
+    let(:parameter) do
+      Simulation::Parameter.new(
         {
           retirement_month: retirement_month,
           employment_month: employment_month,

--- a/spec/models/simulation/residence_spec.rb
+++ b/spec/models/simulation/residence_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Simulation::Residence, type: :model do
   describe '.calc' do
-    subject { Simulation::Residence.calc(param_parser) }
-    let(:param_parser) do
-      Simulation::ParamParser.new(
+    subject { Simulation::Residence.calc(parameter) }
+    let(:parameter) do
+      Simulation::Parameter.new(
         {
           retirement_month: retirement_month,
           employment_month: employment_month,

--- a/spec/models/simulation_spec.rb
+++ b/spec/models/simulation_spec.rb
@@ -47,20 +47,22 @@ RSpec.describe Simulation, type: :model do
       create(:pension, year: 2022, contribution: 16_590)
 
       simulation = Simulation.new(
-        {
-          retirement_month: '2022-03-01',
-          employment_month: '2022-06-01',
-          prefecture: '東京都',
-          city: '千代田区',
-          age: '40',
-          simulation_date: '2022-02-11',
-          previous_salary: '2_000_000',
-          salary: '2_000_000',
-          scheduled_salary: '2_000_000',
-          previous_social_insurance: '100_000',
-          social_insurance: '100_000',
-          scheduled_social_insurance: '100_000'
-        }
+        Simulation::Parameter.new(
+          {
+            retirement_month: '2022-03-01',
+            employment_month: '2022-06-01',
+            prefecture: '東京都',
+            city: '千代田区',
+            age: '40',
+            simulation_date: '2022-02-11',
+            previous_salary: '2_000_000',
+            salary: '2_000_000',
+            scheduled_salary: '2_000_000',
+            previous_social_insurance: '100_000',
+            social_insurance: '100_000',
+            scheduled_social_insurance: '100_000'
+          }
+        )
       )
       expect(simulation.grand_total).to eq 80_781
     end
@@ -111,20 +113,22 @@ RSpec.describe Simulation, type: :model do
 
       expected = { insurance: 12_991, pension: 49_790, residence: 18_000 }
       simulation = Simulation.new(
-        {
-          retirement_month: '2022-03-01',
-          employment_month: '2022-06-01',
-          prefecture: '東京都',
-          city: '千代田区',
-          age: '40',
-          simulation_date: '2022-02-11',
-          previous_salary: '2_000_000',
-          salary: '2_000_000',
-          scheduled_salary: '2_000_000',
-          previous_social_insurance: '100_000',
-          social_insurance: '100_000',
-          scheduled_social_insurance: '100_000'
-        }
+        Simulation::Parameter.new(
+          {
+            retirement_month: '2022-03-01',
+            employment_month: '2022-06-01',
+            prefecture: '東京都',
+            city: '千代田区',
+            age: '40',
+            simulation_date: '2022-02-11',
+            previous_salary: '2_000_000',
+            salary: '2_000_000',
+            scheduled_salary: '2_000_000',
+            previous_social_insurance: '100_000',
+            social_insurance: '100_000',
+            scheduled_social_insurance: '100_000'
+          }
+        )
       )
       expect(simulation.sub_total).to eq expected
     end
@@ -179,20 +183,22 @@ RSpec.describe Simulation, type: :model do
         { month: Time.zone.parse('2022/05/01'), fee: { insurance: 0, pension: 16_590, residence: 0 } }
       ]
       simulation = Simulation.new(
-        {
-          retirement_month: '2022-03-01',
-          employment_month: '2022-06-01',
-          prefecture: '東京都',
-          city: '千代田区',
-          age: '40',
-          simulation_date: '2022-02-11',
-          previous_salary: '2_000_000',
-          salary: '2_000_000',
-          scheduled_salary: '2_000_000',
-          previous_social_insurance: '100_000',
-          social_insurance: '100_000',
-          scheduled_social_insurance: '100_000'
-        }
+        Simulation::Parameter.new(
+          {
+            retirement_month: '2022-03-01',
+            employment_month: '2022-06-01',
+            prefecture: '東京都',
+            city: '千代田区',
+            age: '40',
+            simulation_date: '2022-02-11',
+            previous_salary: '2_000_000',
+            salary: '2_000_000',
+            scheduled_salary: '2_000_000',
+            previous_social_insurance: '100_000',
+            social_insurance: '100_000',
+            scheduled_social_insurance: '100_000'
+          }
+        )
       )
       expect(simulation.monthly_payment).to eq expected
     end

--- a/spec/requests/api/simulations_spec.rb
+++ b/spec/requests/api/simulations_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API::Admin::Simulations', type: :request do
+  describe 'GET /api/simulations?q' do
+    context 'when params is NOT valid' do
+      it 'returns http bad_request' do
+        params = {
+          retirement_month: '2022-03-01',
+          employment_month: '2022-06-01',
+          prefecture: '東京都',
+          city: '千代田区',
+          age: '40',
+          simulation_date: '2022-02-11',
+          previous_salary: '',
+          salary: '',
+          scheduled_salary: '',
+          previous_social_insurance: '',
+          social_insurance: '',
+          scheduled_social_insurance: ''
+        }
+        get api_simulations_path(format: :json), params: params
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end

--- a/spec/support/custom_validator_helper.rb
+++ b/spec/support/custom_validator_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module CustomValidatorHelper
+  def build_validator_mock(attribute: nil, record: nil, validator: nil, options: nil)
+    record    ||= :record
+    attribute ||= :attribute
+    validator ||= described_class.to_s.underscore.gsub(/_validator\Z/, '').to_sym
+    options   ||= true
+
+    Struct.new(attribute, *record, keyword_init: true) do
+      include ActiveModel::Validations
+
+      def self.name
+        'DummyModel'
+      end
+
+      validates attribute, validator => options
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include CustomValidatorHelper, type: :model
+end

--- a/spec/validators/required_salary_and_social_insurance_validator_spec.rb
+++ b/spec/validators/required_salary_and_social_insurance_validator_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RequiredSalaryAndSocialInsuranceValidator, type: :model do
+  describe '#validate' do
+    before { mock.valid? }
+    subject { mock }
+
+    let!(:mock) do
+      record = %i[simulation_date retirement_month employment_month previous_salary previous_social_insurance salary social_insurance scheduled_salary
+                  scheduled_social_insurance]
+      build_validator_mock(record: record).new(
+        simulation_date: simulation_date,
+        retirement_month: retirement_month,
+        employment_month: employment_month,
+        previous_salary: previous_salary,
+        previous_social_insurance: previous_social_insurance,
+        salary: salary,
+        social_insurance: social_insurance,
+        scheduled_salary: scheduled_salary,
+        scheduled_social_insurance: scheduled_social_insurance
+      )
+    end
+
+    context 'when retirement_month < Jun' do
+      let!(:simulation_date) { Time.zone.parse('2022-04-01') }
+      let!(:retirement_month) { Time.zone.parse('2022-05-01') }
+      let!(:employment_month) { Time.zone.parse('2023-03-01') }
+      let!(:salary) { 5_000_000 }
+      let!(:social_insurance) { 750_000 }
+      let!(:scheduled_salary) { 5_000_000 }
+      let!(:scheduled_social_insurance) { 750_000 }
+
+      context 'when previous_salary is nil' do
+        let!(:previous_salary) { nil }
+        let!(:previous_social_insurance) { 750_000 }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when previous_social_insurance is nil' do
+        let!(:previous_salary) { 5_000_000 }
+        let!(:previous_social_insurance) { nil }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when previous_salary and previous_social_insurance are nil' do
+        let!(:previous_salary) { nil }
+        let!(:previous_social_insurance) { nil }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when previous_salary and previous_social_insurance are NOT nil' do
+        let!(:previous_salary) { 5_000_000 }
+        let!(:previous_social_insurance) { 750_000 }
+        it { is_expected.to be_valid }
+      end
+    end
+
+    context 'when retirement_month >= Jun && retirement_month < next Jun' do
+      let!(:simulation_date) { Time.zone.parse('2022-06-01') }
+      let!(:retirement_month) { Time.zone.parse('2022-12-01') }
+      let!(:employment_month) { Time.zone.parse('2023-04-01') }
+      let!(:previous_salary) { nil }
+      let!(:previous_social_insurance) { nil }
+      let!(:salary) { 5_000_000 }
+      let!(:social_insurance) { 750_000 }
+
+      context 'when previous_salary is nil' do
+        let!(:scheduled_salary) { nil }
+        let!(:scheduled_social_insurance) { 750_000 }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when previous_social_insurance is nil' do
+        let!(:scheduled_salary) { 5_000_000 }
+        let!(:scheduled_social_insurance) { nil }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when previous_salary and previous_social_insurance are nil' do
+        let!(:scheduled_salary) { nil }
+        let!(:scheduled_social_insurance) { nil }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when previous_salary and previous_social_insurance are NOT nil' do
+        let!(:scheduled_salary) { 5_000_000 }
+        let!(:scheduled_social_insurance) { 750_000 }
+        it { is_expected.to be_valid }
+      end
+    end
+
+    context 'when employment_month >= next Apr' do
+      let!(:simulation_date) { Time.zone.parse('2022-06-01') }
+      let!(:retirement_month) { Time.zone.parse('2023-05-01') }
+      let!(:employment_month) { Time.zone.parse('2023-06-01') }
+      let!(:previous_salary) { nil }
+      let!(:previous_social_insurance) { nil }
+      let!(:scheduled_salary) { 5_000_000 }
+      let!(:scheduled_social_insurance) { 750_000 }
+
+      context 'when previous_salary is nil' do
+        let!(:salary) { nil }
+        let!(:social_insurance) { 750_000 }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when previous_social_insurance is nil' do
+        let!(:salary) { 5_000_000 }
+        let!(:social_insurance) { nil }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when previous_salary and previous_social_insurance are nil' do
+        let!(:salary) { nil }
+        let!(:social_insurance) { nil }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when previous_salary and previous_social_insurance are NOT nil' do
+        let!(:salary) { 5_000_000 }
+        let!(:social_insurance) { 750_000 }
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## やったこと

- API::Simulationsをコールした際、計算処理開始前にバリデーションを実行し、エラーがあれば400（BadRequest）を返すようにした
    - バリエーションの実行タイミング的に、従来の`Simulation::ParamParser`を`Simulation`に先行して生成するよう修正
    - 有効なパラメータを持ち、それ自体を`Simulation`に渡すので、`Simulation::ParamParser`から`Simulation::Parameter`に変更
    - バリデーション実行に伴い、型キャストもActiveModelの機能（`ActiveModel::Attributes`）で実行するように変更

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
