### PR TITLE
計算処理が失敗した場合は、エラーをモーダルで表示する

### DIFF
--- a/app/javascript/src/components/SimulationResult.vue
+++ b/app/javascript/src/components/SimulationResult.vue
@@ -138,10 +138,33 @@ import LoadingAnimation from './LoadingAnimation'
 const router = useRouter()
 const { simulation } = useGlobalStore()
 
-simulation.load_result()
+let result = $ref({})
+let loading = $ref(false)
+const parameter = $computed(() => simulation.parameter)
 
-const result = $computed(() => simulation.result)
-const loading = $computed(() => simulation.loading)
+const loadResult = async () => {
+  loading = true
+  try {
+    const simulationApi = `/api/simulations?${parameter}`
+    const response = await fetch(simulationApi, {
+      method: 'GET',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+      redirect: 'manual'
+    })
+
+    if (!response.ok) throw new Error(response.statusText)
+
+    const json = await response.json()
+    result = json.simulation
+  } catch (e) {
+    console.warn(e)
+  } finally {
+    loading = false
+  }
+}
+
+loadResult()
 
 const formatDate = (dateString) => {
   return format(new Date(dateString), 'yyyy年MM月')

--- a/app/javascript/src/components/SimulationResult.vue
+++ b/app/javascript/src/components/SimulationResult.vue
@@ -1,131 +1,134 @@
 <template>
   <LoadingAnimation v-if="loading" />
   <div v-else>
-    <div class="md:max-w-screen-lg md:mx-auto pt-12 md:pt-32 text-center">
-      <div class="flex md:flex-row md:justify-center flex-col mb-6">
-        <p class="text-lg md:text-3xl">
-          {{ formatDate(result.retirement_month) }}に退職して、
-        </p>
-        <p class="text-lg md:text-3xl">
-          {{ formatDate(result.employment_month) }}に就職すると...
-        </p>
-      </div>
-      <div
-        class="flex md:flex-row md:justify-center md:items-end gap-8 md:gap-2 flex-col mb-10 md:mx-42"
-      >
-        <p>
-          <span>約</span>
-          <span class="mx-4">
-            <span class="text-6xl md:text-8xl text-primary">{{
-              formatAmount(result.grand_total)
-            }}</span>
-            <span class="text-base md:text-3xl text-primary ml-2">円</span>
-          </span>
-        </p>
-        <p>かかります</p>
-      </div>
-      <div
-        class="mb-8 md:mb-20 md:justify-center flex md:flex-row flex-col md:gap-x-4 items-start md:px-56 px-24"
-      >
-        <div
-          class="flex flex-row justify-between items-center md:flex-col gap-y-2 md:basis-full w-full"
-        >
-          <p
-            class="text-xs md:text-sm underline underline-offset-2 decoration-4 decoration-primary"
-          >
-            国民健康保険
+    <SimulationResultError v-if="simulationError" />
+    <template v-else>
+      <div class="md:max-w-screen-lg md:mx-auto pt-12 md:pt-32 text-center">
+        <div class="flex md:flex-row md:justify-center flex-col mb-6">
+          <p class="text-lg md:text-3xl">
+            {{ formatDate(result.retirement_month) }}に退職して、
           </p>
-          <p class="text-lg md:text-xl">
-            {{ formatAmount(result.sub_total.insurance) }}円
+          <p class="text-lg md:text-3xl">
+            {{ formatDate(result.employment_month) }}に就職すると...
           </p>
         </div>
         <div
-          class="flex flex-row justify-between items-center md:flex-col gap-y-2 md:basis-full w-full"
+          class="flex md:flex-row md:justify-center md:items-end gap-8 md:gap-2 flex-col mb-10 md:mx-42"
         >
-          <p
-            class="text-xs md:text-sm underline underline-offset-2 decoration-4 decoration-red-600"
-          >
-            国民年金
+          <p>
+            <span>約</span>
+            <span class="mx-4">
+              <span class="text-6xl md:text-8xl text-primary">{{
+                formatAmount(result.grand_total)
+              }}</span>
+              <span class="text-base md:text-3xl text-primary ml-2">円</span>
+            </span>
           </p>
-          <p class="text-lg md:text-xl">
-            {{ formatAmount(result.sub_total.pension) }}円
-          </p>
+          <p>かかります</p>
         </div>
         <div
-          class="flex flex-row justify-between items-center md:flex-col gap-y-2 md:basis-full w-full"
+          class="mb-8 md:mb-20 md:justify-center flex md:flex-row flex-col md:gap-x-4 items-start md:px-56 px-24"
         >
-          <p
-            class="text-xs md:text-sm underline underline-offset-2 decoration-4 decoration-yellow-500"
+          <div
+            class="flex flex-row justify-between items-center md:flex-col gap-y-2 md:basis-full w-full"
           >
-            住民税
-          </p>
-          <p class="text-lg md:text-xl">
-            {{ formatAmount(result.sub_total.residence) }}円
-          </p>
-        </div>
-      </div>
-      <div class="flex flex-wrap justify-around mb-8 md:mb-52 md:px-32">
-        <button
-          class="text-sm md:text-lg w-52 md:w-64 flex justify-between items-center bg-primary text-white rounded-full px-6 md:px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary before:content-[''] before:w-2 md:before:w-3 before:h-2 md:before:h-3 before:rotate-45 before:border-solid before:border-white before:border-b-4 before:border-l-4 before:hover:border-gray"
-          @click="moveForm"
-        >
-          もういちど計算する
-        </button>
-        <button
-          class="hidden md:flex text-lg w-60 flex justify-evenly items-center bg-accent text-white rounded-full px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-accent after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray"
-          @click="scrollDetail"
-        >
-          詳細をみる
-        </button>
-      </div>
-    </div>
-    <div class="bg-secondary py-4 md:py-12" id="detail">
-      <div class="md:max-w-screen-lg md:mx-auto p-4 md:p-12">
-        <h2
-          class="text-center text-xl md:text-3xl mb-12 underline underline-offset-8 decoration-4 decoration-primary"
-        >
-          個人負担額の詳細
-        </h2>
-        <div
-          v-for="monthly_payment in result.monthly_payment"
-          :key="monthly_payment.month"
-          class="px-6 md:px-8 py-5 md:py-8 mb-4 last:mb-0 shadow-md bg-white rounded-xl"
-        >
-          <div class="separator">
+            <p
+              class="text-xs md:text-sm underline underline-offset-2 decoration-4 decoration-primary"
+            >
+              国民健康保険
+            </p>
             <p class="text-lg md:text-xl">
-              {{ formatDate(monthly_payment.month) }}
+              {{ formatAmount(result.sub_total.insurance) }}円
             </p>
           </div>
-          <div class="px-2 pt-4">
-            <ul>
-              <li
-                class="type-icon before:content-['健康保険'] mb-4 before:bg-primary"
-              >
-                {{ formatAmount(monthly_payment.fee.insurance) }}円
-              </li>
-              <li
-                class="type-icon before:content-['国民年金'] mb-4 before:bg-red-600"
-              >
-                {{ formatAmount(monthly_payment.fee.pension) }}円
-              </li>
-              <li
-                class="type-icon before:content-['住民税'] before:bg-yellow-500"
-              >
-                {{ formatAmount(monthly_payment.fee.residence) }}円
-              </li>
-            </ul>
+          <div
+            class="flex flex-row justify-between items-center md:flex-col gap-y-2 md:basis-full w-full"
+          >
+            <p
+              class="text-xs md:text-sm underline underline-offset-2 decoration-4 decoration-red-600"
+            >
+              国民年金
+            </p>
+            <p class="text-lg md:text-xl">
+              {{ formatAmount(result.sub_total.pension) }}円
+            </p>
+          </div>
+          <div
+            class="flex flex-row justify-between items-center md:flex-col gap-y-2 md:basis-full w-full"
+          >
+            <p
+              class="text-xs md:text-sm underline underline-offset-2 decoration-4 decoration-yellow-500"
+            >
+              住民税
+            </p>
+            <p class="text-lg md:text-xl">
+              {{ formatAmount(result.sub_total.residence) }}円
+            </p>
           </div>
         </div>
+        <div class="flex flex-wrap justify-around mb-8 md:mb-52 md:px-32">
+          <button
+            class="text-sm md:text-lg w-52 md:w-64 flex justify-between items-center bg-primary text-white rounded-full px-6 md:px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary before:content-[''] before:w-2 md:before:w-3 before:h-2 md:before:h-3 before:rotate-45 before:border-solid before:border-white before:border-b-4 before:border-l-4 before:hover:border-gray"
+            @click="moveForm"
+          >
+            もういちど計算する
+          </button>
+          <button
+            class="hidden md:flex text-lg w-60 flex justify-evenly items-center bg-accent text-white rounded-full px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-accent after:content-[''] after:w-3 after:h-3 after:rotate-45 after:border-solid after:border-white after:border-t-4 after:border-r-4 after:hover:border-gray"
+            @click="scrollDetail"
+          >
+            詳細をみる
+          </button>
+        </div>
       </div>
-      <div class="flex justify-center my-4">
-        <button
-          class="text-sm md:text-lg w-48 md:w-52 flex justify-evenly items-center bg-primary text-white rounded-full px-4 md:px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary after:content-[''] after:w-2 after:h-2 md:after:w-3 md:after:h-3 after:rotate-45 after:border-solid after:border-white after:border-l-4 after:border-t-4 after:hover:border-gray"
-          @click="scrollTop"
-        >
-          ページ上部へ
-        </button>
+      <div class="bg-secondary py-4 md:py-12" id="detail">
+        <div class="md:max-w-screen-lg md:mx-auto p-4 md:p-12">
+          <h2
+            class="text-center text-xl md:text-3xl mb-12 underline underline-offset-8 decoration-4 decoration-primary"
+          >
+            個人負担額の詳細
+          </h2>
+          <div
+            v-for="monthly_payment in result.monthly_payment"
+            :key="monthly_payment.month"
+            class="px-6 md:px-8 py-5 md:py-8 mb-4 last:mb-0 shadow-md bg-white rounded-xl"
+          >
+            <div class="separator">
+              <p class="text-lg md:text-xl">
+                {{ formatDate(monthly_payment.month) }}
+              </p>
+            </div>
+            <div class="px-2 pt-4">
+              <ul>
+                <li
+                  class="type-icon before:content-['健康保険'] mb-4 before:bg-primary"
+                >
+                  {{ formatAmount(monthly_payment.fee.insurance) }}円
+                </li>
+                <li
+                  class="type-icon before:content-['国民年金'] mb-4 before:bg-red-600"
+                >
+                  {{ formatAmount(monthly_payment.fee.pension) }}円
+                </li>
+                <li
+                  class="type-icon before:content-['住民税'] before:bg-yellow-500"
+                >
+                  {{ formatAmount(monthly_payment.fee.residence) }}円
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="flex justify-center my-4">
+          <button
+            class="text-sm md:text-lg w-48 md:w-52 flex justify-evenly items-center bg-primary text-white rounded-full px-4 md:px-8 py-5 ease-in duration-100 hover:bg-white hover:text-gray border-4 border-primary after:content-[''] after:w-2 after:h-2 md:after:w-3 md:after:h-3 after:rotate-45 after:border-solid after:border-white after:border-l-4 after:border-t-4 after:hover:border-gray"
+            @click="scrollTop"
+          >
+            ページ上部へ
+          </button>
+        </div>
       </div>
-    </div>
+    </template>
   </div>
 </template>
 
@@ -134,16 +137,19 @@ import { format } from 'date-fns'
 import { useRouter } from 'vue-router'
 import { useGlobalStore } from '../store/global'
 import LoadingAnimation from './LoadingAnimation'
+import SimulationResultError from './SimulationResultError'
 
 const router = useRouter()
 const { simulation } = useGlobalStore()
 
 let result = $ref({})
 let loading = $ref(false)
+let simulationError = $ref(false)
 const parameter = $computed(() => simulation.parameter)
 
 const loadResult = async () => {
   loading = true
+  simulationError = false
   try {
     const simulationApi = `/api/simulations?${parameter}`
     const response = await fetch(simulationApi, {
@@ -158,7 +164,7 @@ const loadResult = async () => {
     const json = await response.json()
     result = json.simulation
   } catch (e) {
-    console.warn(e)
+    simulationError = true
   } finally {
     loading = false
   }

--- a/app/javascript/src/components/SimulationResultError.vue
+++ b/app/javascript/src/components/SimulationResultError.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="fixed z-10 inset-0 overflow-y-auto bg-black bg-opacity-50">
+    <div class="flex items-start justify-center min-h-screen pt-56">
+      <div
+        class="border-0 rounded-lg shadow-lg relative flex flex-col w-11/12 md:w-5/12 bg-white outline-none focus:outline-none"
+      >
+        <header
+          class="flex items-start justify-between p-5 border-b border-solid border-boundaryBlack rounded-t"
+        >
+          <h3 class="text-xl">エラーが発生しました</h3>
+        </header>
+        <article class="relative p-4 flex-auto">
+          <p class="text-black text-xs md:text-sm leading-relaxed">
+            画面をリロードするか、時間をおいて、もう一度最初からお試しください。
+          </p>
+          <p class="mt-1 text-black text-xs md:text-sm leading-relaxed">
+            エラーが出続ける場合は以下の「Twitterから連絡」から @ikuma-t
+            までご連絡ください。
+          </p>
+        </article>
+        <footer
+          class="flex items-center justify-end p-2 border-t border-solid border-boundaryBlack rounded-b"
+        >
+          <a
+            class="text-white bg-sky-500 border border-solid rounded-md text-xs px-3 py-3 rounded outline-none focus:outline-none mr-1 mb-1"
+            href="https://twitter.com/ikumatdkr"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Twitterから連絡
+          </a>
+          <button
+            class="text-white bg-primary border border-solid rounded-md text-xs px-3 py-3 rounded outline-none focus:outline-none mr-1 mb-1"
+            @click="moveForm"
+          >
+            最初からやり直す
+          </button>
+        </footer>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useRouter } from 'vue-router'
+import { useGlobalStore } from '../store/global'
+
+const router = useRouter()
+const { simulation } = useGlobalStore()
+
+const moveForm = () => {
+  router.push('/simulations/new')
+  simulation.reset()
+}
+</script>

--- a/app/javascript/src/store/simulation.js
+++ b/app/javascript/src/store/simulation.js
@@ -31,9 +31,7 @@ export default function simulationStore() {
         simulationDate: new Date()
       },
       routes: [...defaultRoute],
-      currentStep: 0,
-      loading: false,
-      result: {}
+      currentStep: 0
     },
     sessionStorage
   )
@@ -61,37 +59,6 @@ export default function simulationStore() {
 
     state.value.routes = newRoute
   })
-
-  const formatDate = (date) => format(date, 'yyyy-MM-dd')
-
-  const getResult = async () => {
-    const params = state.value.params
-    const [prefecture, city] = params.address.split(' ')
-    const parameter = new URLSearchParams({
-      simulation_date: formatDate(new Date(params.simulationDate)),
-      retirement_month: formatDate(new Date(`${params.retirementMonth}/1`)),
-      employment_month: formatDate(new Date(`${params.employmentMonth}/1`)),
-      age: params.age,
-      prefecture,
-      city,
-      previous_salary: params.previousSalary,
-      salary: params.salary,
-      scheduled_salary: params.scheduledSalary,
-      previous_social_insurance: params.previousSocialInsurance,
-      social_insurance: params.socialInsurance,
-      scheduled_social_insurance: params.scheduledSocialInsurance
-    }).toString()
-
-    const simulationApi = `/api/simulations?${parameter}`
-    const response = await fetch(simulationApi, {
-      method: 'GET',
-      headers: { 'X-Requested-With': 'XMLHttpRequest' },
-      credentials: 'same-origin',
-      redirect: 'manual'
-    })
-    const json = await response.json()
-    return json.simulation
-  }
 
   return {
     get params() {
@@ -152,16 +119,26 @@ export default function simulationStore() {
       return [...completedRoute, nextRoute]
     },
 
-    get result() {
-      return state.value.result
-    },
+    get parameter() {
+      const formatDate = (date) => format(date, 'yyyy-MM-dd')
+      const params = state.value.params
+      const [prefecture, city] = params.address.split(' ')
+      const parameter = new URLSearchParams({
+        simulation_date: formatDate(new Date(params.simulationDate)),
+        retirement_month: formatDate(new Date(`${params.retirementMonth}/1`)),
+        employment_month: formatDate(new Date(`${params.employmentMonth}/1`)),
+        age: params.age,
+        prefecture,
+        city,
+        previous_salary: params.previousSalary,
+        salary: params.salary,
+        scheduled_salary: params.scheduledSalary,
+        previous_social_insurance: params.previousSocialInsurance,
+        social_insurance: params.socialInsurance,
+        scheduled_social_insurance: params.scheduledSocialInsurance
+      }).toString()
 
-    get loading() {
-      return state.value.loading
-    },
-
-    get numberOfStep() {
-      return state.value.route.length
+      return parameter
     },
 
     add_params(values) {
@@ -173,18 +150,8 @@ export default function simulationStore() {
 
     reset() {
       state.value.params = { simulationDate: new Date() }
-      state.value.result = {}
       state.value.routes = [...defaultRoute]
       state.value.currentStep = 0
-    },
-
-    async load_result() {
-      state.value.loading = true
-      try {
-        state.value.result = await getResult()
-      } finally {
-        state.value.loading = false
-      }
     }
   }
 }

--- a/app/javascript/test/unit/store/simulation.spec.js
+++ b/app/javascript/test/unit/store/simulation.spec.js
@@ -27,7 +27,6 @@ describe('#reset', () => {
   it('reset params, result, routes and currentStep', () => {
     simulation.reset()
     expect(simulation.params).toEqual({ simulationDate: mockDate })
-    expect(simulation.result).toEqual({})
     expect(simulation.steps).toEqual(10)
     expect(simulation.currentStepIdx).toEqual(0)
   })


### PR DESCRIPTION
Closes: #251 

計算処理が失敗した場合には、エラーである旨をモーダルで表示するように変更。
クライアント側でもバリデーションをかけているので、基本的に業務エラーは取り除いていること、ステータスコードがどうであってもクライアント側で試行錯誤して取れるアクションはないため、Rails側はエラーハンドリングをせずに、Vue側で一律エラーがあればモーダルを表示する。

## UIの変更

`/simaulations`

エラーの場合は以下のように表示されます。

![image](https://user-images.githubusercontent.com/61409641/161501252-a4804f3c-d92d-4f63-b666-7cad45106ec2.png)

- 「Twitterから連絡する」：別タブで https://twitter.com/ikumatdkr を開く
- 「最初からやり直す」：値をリセットして、`/simulations/new`に移動する

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
