### PR TITLE
ci(release): mainにpushされたらstagingへのPRを自動作成する

### DIFF
--- a/.github/workflows/git-pr-release-action.yml
+++ b/.github/workflows/git-pr-release-action.yml
@@ -1,0 +1,20 @@
+name: Create a release pull-request
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release_pull_request:
+    runs-on: ubuntu-latest
+    name: release_pull_request
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: create-release-pr
+        uses: grassedge/git-pr-release-action@v1.0
+        with:
+          base: production
+          head: main
+          token: ${{ secrets.QUITCOST_GITHUB_TOKEN }}
+          labels: release
+          assign: true


### PR DESCRIPTION
fjordbootcampの設定を参考にしました

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
