### PR TITLE
管理者画面の配色を一部変更する

### DIFF
--- a/app/javascript/src/components/Insurances.vue
+++ b/app/javascript/src/components/Insurances.vue
@@ -166,7 +166,7 @@
         v-model="currentPage"
         :pages="totalPages"
         :range-size="1"
-        active-color="#117766"
+        active-color="#DFEEE5"
         @update:modelValue="switchPage"
       />
     </nav>

--- a/app/javascript/src/components/Pensions.vue
+++ b/app/javascript/src/components/Pensions.vue
@@ -53,7 +53,7 @@
           v-model="currentPage"
           :pages="totalPages"
           :range-size="1"
-          active-color="#117766"
+          active-color="#DFEEE5"
           @update:modelValue="switchPage"
         />
       </nav>

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -31,10 +31,10 @@ html
                 = link_to 'ログアウト', destroy_user_session_path, method: :delete
     - if notice
       .w-full
-        .p-24.bg-secondary.items-center.text-white.leading-none.flex.py-3
-          span.flex.rounded-full.bg-primary.uppercase.px-2.py-1.text-xs.mr-3
+        .p-24.bg-secondary.items-center.leading-none.flex.py-3
+          span.flex.rounded-full.bg-primary.uppercase.px-2.py-1.text-xs.mr-3.text-white
             | INFO
-          span.font-semibold.mr-2.text-left.text-sm.lex-auto
+          span.mr-2.text-left.text-sm.lex-auto.text-black
             = notice
     - if alert
       .w-full


### PR DESCRIPTION
Closes: #276 

## UIの変更

### アラート

**変更前**

![image](https://user-images.githubusercontent.com/61409641/161941741-34f6eca0-bc3e-4272-bc87-b1a39bef995f.png)

**変更後**

![image](https://user-images.githubusercontent.com/61409641/161941718-901d8672-8908-4f43-8461-6722ccf7bf7c.png)

### ページネーションの色

**変更前**

![image](https://user-images.githubusercontent.com/61409641/161941961-76098720-9092-44d5-8efc-cddcce3624b5.png)


**変更後**

![CleanShot 2022-04-06 at 18 18 58](https://user-images.githubusercontent.com/61409641/161941889-1699c4d6-89f9-4871-b3e2-01ef71b1621a.png)


---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [ ] 関連するコミットはsquashした
- [ ] テストを追加した
- [ ] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
