### PR TITLE
Safariでもアプリが起動できるようにする

### DIFF
--- a/app/javascript/src/components/simulation_form/EmploymentMonth.vue
+++ b/app/javascript/src/components/simulation_form/EmploymentMonth.vue
@@ -7,7 +7,7 @@
     id="employmentMonth"
     class="form-field text-center"
     type="text"
-    v-maska="{ mask: '####/##' }"
+    v-maska="{ mask: '####-##' }"
     :value="employmentMonth"
     :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
@@ -32,8 +32,8 @@ const params = $computed(() => simulation.params)
 
 const base = new Date(params.simulationDate)
 const { endOfYear } = useFinancialYear(addYears(base, 1), 4)
-const from = format(base, 'yyyy/MM')
-const to = format(addMonths(endOfYear, 1), 'yyyy/MM')
+const from = format(base, 'yyyy-MM')
+const to = format(addMonths(endOfYear, 1), 'yyyy-MM')
 
 let { value: retirementMonth } = useField('retirementMonth')
 let {

--- a/app/javascript/src/components/simulation_form/RetirementMonth.vue
+++ b/app/javascript/src/components/simulation_form/RetirementMonth.vue
@@ -7,7 +7,7 @@
     id="retirementMonth"
     class="text-center"
     type="text"
-    v-maska="{ mask: '####/##' }"
+    v-maska="{ mask: '####-##' }"
     :value="retirementMonth"
     :class="error ? 'form-field-error' : 'form-field'"
     @change="handleChange"
@@ -32,8 +32,8 @@ const params = $computed(() => simulation.params)
 
 const base = new Date(params.simulationDate)
 const { endOfYear } = useFinancialYear(addYears(base, 1), 4)
-const from = format(base, 'yyyy/MM')
-const to = format(addMonths(endOfYear, 1), 'yyyy/MM')
+const from = format(base, 'yyyy-MM')
+const to = format(addMonths(endOfYear, 1), 'yyyy-MM')
 
 let {
   value: retirementMonth,

--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -4,8 +4,8 @@ import { format } from 'date-fns'
 
 export const useValidationSchema = (baseDate) => {
   const { afterNextBeginningOfYear } = useFinancialYear(baseDate, 4)
-  const from = format(baseDate, 'yyyy/MM')
-  const to = format(afterNextBeginningOfYear, 'yyyy/MM')
+  const from = format(baseDate, 'yyyy-MM')
+  const to = format(afterNextBeginningOfYear, 'yyyy-MM')
 
   const numberPresence = (columnName) => {
     return number()

--- a/app/javascript/src/store/simulation.js
+++ b/app/javascript/src/store/simulation.js
@@ -114,7 +114,9 @@ export default function simulationStore() {
       const completedRoute = camelizeAnswer.filter((route) =>
         state.value.routes.includes(route)
       )
-      const lastStep = state.value.routes.indexOf(completedRoute.at(-1)) + 1
+      const lastStep =
+        state.value.routes.indexOf(completedRoute[completedRoute.length - 1]) +
+        1
       const nextRoute = state.value.routes[lastStep]
       return [...completedRoute, nextRoute]
     },

--- a/app/javascript/src/store/simulation.js
+++ b/app/javascript/src/store/simulation.js
@@ -127,8 +127,8 @@ export default function simulationStore() {
       const [prefecture, city] = params.address.split(' ')
       const parameter = new URLSearchParams({
         simulation_date: formatDate(new Date(params.simulationDate)),
-        retirement_month: formatDate(new Date(`${params.retirementMonth}/1`)),
-        employment_month: formatDate(new Date(`${params.employmentMonth}/1`)),
+        retirement_month: formatDate(new Date(`${params.retirementMonth}`)),
+        employment_month: formatDate(new Date(`${params.employmentMonth}`)),
         age: params.age,
         prefecture,
         city,

--- a/app/javascript/test/unit/composables/useValidationSchema.spec.js
+++ b/app/javascript/test/unit/composables/useValidationSchema.spec.js
@@ -28,28 +28,28 @@ describe('#validationSchema', () => {
     })
 
     it('is invalid with the month before the month of today', async () => {
-      const target = { retirementMonth: '2022/02' }
+      const target = { retirementMonth: '2022-02' }
       await expect(schema.validate(target)).rejects.toThrow(
-        '退職予定月には 2022/03 以降の月を指定してください'
+        '退職予定月には 2022-03 以降の月を指定してください'
       )
     })
 
     it('is valid with the month of today', async () => {
-      const target = { retirementMonth: '2022/03' }
+      const target = { retirementMonth: '2022-03' }
       await expect(schema.validate(target)).resolves.toEqual({
         retirementMonth: new Date('2022-03-01')
       })
     })
 
     it('is invalid a month later than the beginning of the financial year two years later', async () => {
-      const target = { retirementMonth: '2023/05' }
+      const target = { retirementMonth: '2023-05' }
       await expect(schema.validate(target)).rejects.toThrow(
-        '退職予定月には 2023/04 以前の月を指定してください'
+        '退職予定月には 2023-04 以前の月を指定してください'
       )
     })
 
     it('is valid with the beginning of the financial year two years later', async () => {
-      const target = { retirementMonth: '2023/04' }
+      const target = { retirementMonth: '2023-04' }
       await expect(schema.validate(target)).resolves.toEqual({
         retirementMonth: new Date('2023-04-01')
       })
@@ -67,21 +67,21 @@ describe('#validationSchema', () => {
     })
 
     it('is invalid the month before retirementMonth', async () => {
-      const target = { retirementMonth: '2022/08', employmentMonth: '2022/06' }
+      const target = { retirementMonth: '2022-08', employmentMonth: '2022-06' }
       await expect(schema.validate(target)).rejects.toThrow(
         '転職予定月には、退職予定月以降の月を指定してください'
       )
     })
 
     it('is invalid a month later than the beginning of the financial year two years later', async () => {
-      const target = { retirementMonth: '2022/08', employmentMonth: '2023/05' }
+      const target = { retirementMonth: '2022-08', employmentMonth: '2023-05' }
       await expect(schema.validate(target)).rejects.toThrow(
-        '転職予定月には 2023/04 以前の月を指定してください'
+        '転職予定月には 2023-04 以前の月を指定してください'
       )
     })
 
     it('is valid with the beginning of the financial year two years later', async () => {
-      const target = { retirementMonth: '2022/08', employmentMonth: '2023/04' }
+      const target = { retirementMonth: '2022-08', employmentMonth: '2023-04' }
       await expect(schema.validate(target)).resolves.toEqual({
         retirementMonth: new Date('2022-08-01'),
         employmentMonth: new Date('2023-04-01')


### PR DESCRIPTION
## 目的

Safariの仕様では動かないJavaScriptがあるので、Safariでも動くようにする。

## やったこと

- Array.prototype.atを使用しないように変更
    - 参考：https://caniuse.com/mdn-javascript_builtins_array_at
    - Safariで15.4以降しか対応していないため。
    - 現時点でSafari 15.4（2022.03.15リリース）の普及率は低いため、対応バージョンが増えるまではこのAPIを使用しないようにする
- Dateを`yyyy/MM`から、`yyyy-MM`に変更
    - Safariだと`yyyy/MM`ではInvalid Dateになってしまうため。

## UIの変更

![CleanShot 2022-04-11 at 16 30 24](https://user-images.githubusercontent.com/61409641/162686747-42ac23c9-52cf-43d8-a2a9-6daf48b5e349.png)

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
