### PR TITLE
fix(validation): 日付のparseに失敗した場合のエラーメッセージが不足していたので追加

### DIFF
--- a/app/javascript/src/composables/useValidationSchema.js
+++ b/app/javascript/src/composables/useValidationSchema.js
@@ -19,6 +19,7 @@ export const useValidationSchema = (baseDate) => {
       .nullable()
       .transform((value, original) => (original === '' ? null : value))
       .required(`${columnName}は必須です`)
+      .typeError('無効な日付形式です。')
   }
 
   const RetirementMonth = object({


### PR DESCRIPTION
## やったこと

yup標準のバリデーションメッセージが出ていた部分を修正

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
