### PR TITLE
Insurance::BaseのAPIの位置付けを変更

### DIFF
--- a/app/models/simulation/insurance/base.rb
+++ b/app/models/simulation/insurance/base.rb
@@ -21,7 +21,7 @@ class Simulation::Insurance::Base
     calculate_result <= limit ? calculate_result : limit
   end
 
-  private
+  protected
 
   attr_reader :rate, :age
 

--- a/app/models/simulation/insurance/base.rb
+++ b/app/models/simulation/insurance/base.rb
@@ -4,7 +4,7 @@ class Simulation::Insurance::Base
   BASIC_DEDUCTION = 430_000
 
   def self.calc(year:, local_gov_code:, income:, age:)
-    new(year, local_gov_code, income, age).calc
+    new(year, local_gov_code, income, age).calculate
   end
 
   def initialize(year, local_gov_code, income, age)
@@ -13,14 +13,6 @@ class Simulation::Insurance::Base
     @age = age
   end
 
-  def calc
-    calculate
-  end
-
-  private
-
-  attr_reader :rate, :age
-
   def calculate
     return 0 if age >= 75
 
@@ -28,6 +20,10 @@ class Simulation::Insurance::Base
     calculate_result = income_basis + capita_basis + household_basis
     calculate_result <= limit ? calculate_result : limit
   end
+
+  private
+
+  attr_reader :rate, :age
 
   # 所得割
   def income_basis

--- a/app/models/simulation/insurance/base.rb
+++ b/app/models/simulation/insurance/base.rb
@@ -14,30 +14,28 @@ class Simulation::Insurance::Base
   end
 
   def calculate
-    return 0 if age >= 75
+    return 0 if @age >= 75
 
-    limit = rate.send("#{name}_limit")
+    limit = @rate.send("#{name}_limit")
     calculate_result = income_basis + capita_basis + household_basis
     calculate_result <= limit ? calculate_result : limit
   end
 
   protected
 
-  attr_reader :rate, :age
-
   # 所得割
   def income_basis
-    (salary * rate.send("#{name}_income_basis") / 100).round
+    (salary * @rate.send("#{name}_income_basis") / 100).round
   end
 
   # 均等割
   def capita_basis
-    rate.send("#{name}_capita_basis")
+    @rate.send("#{name}_capita_basis")
   end
 
   # 世帯割
   def household_basis
-    rate.send("#{name}_household_basis")
+    @rate.send("#{name}_household_basis")
   end
 
   def name

--- a/app/models/simulation/insurance/care.rb
+++ b/app/models/simulation/insurance/care.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Simulation::Insurance::Care < Simulation::Insurance::Base
-  private
-
   def calculate
     return 0 if age < 40 || age >= 65
 

--- a/app/models/simulation/insurance/care.rb
+++ b/app/models/simulation/insurance/care.rb
@@ -2,7 +2,7 @@
 
 class Simulation::Insurance::Care < Simulation::Insurance::Base
   def calculate
-    return 0 if age < 40 || age >= 65
+    return 0 if @age < 40 || @age >= 65
 
     super
   end


### PR DESCRIPTION
Closes: #311 

## やったこと

- 実装意図が分かりづらい（実質的には意味がない）ラッパーメソッド（privateな`calculate`を`calc`でラップ）を削除
- 親クラスで実装しているprivateなメソッドについて、今後計算処理を厳密化する場合に子クラス側で拡張する可能性があるのでvisibilityをprotectedに変更

---

PR提出前のチェックリスト:

- [ ] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [ ] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
