### PR TITLE
Privateなattr_readerをインスタンス変数直接参照に変更

### DIFF
--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -32,17 +32,15 @@ class Simulation
 
   private
 
-  attr_reader :parameter
-
   def insurance
-    Simulation::Insurance.calc(parameter)
+    Simulation::Insurance.calc(@parameter)
   end
 
   def pension
-    Simulation::Pension.calc(parameter)
+    Simulation::Pension.calc(@parameter)
   end
 
   def residence
-    Simulation::Residence.calc(parameter)
+    Simulation::Residence.calc(@parameter)
   end
 end

--- a/app/models/simulation/insurance.rb
+++ b/app/models/simulation/insurance.rb
@@ -21,8 +21,6 @@ class Simulation::Insurance
 
   private
 
-  attr_reader :from, :to, :local_gov_code, :age, :salary_table
-
   def monthly_insurance
     yearly_insurance.flat_map do |year, fee|
       unemployed_term = unemployed_term_by_fiscal_year[year]
@@ -41,14 +39,14 @@ class Simulation::Insurance
   def yearly_insurance
     result = {}
     fiscal_years.each do |year|
-      salary = salary_table[year]
+      salary = @salary_table[year]
       result[year] = LocalTaxLaw.calc_determined_amount { calc_medical(year, salary) + calc_elderly(year, salary) + calc_care(year, salary) }
     end
     result
   end
 
   def build_payment_target_month(year)
-    months = Insurance.rate(year: year, local_gov_code: local_gov_code).payment_target_months.map(&:month)
+    months = Insurance.rate(year: year, local_gov_code: @local_gov_code).payment_target_months.map(&:month)
     diff = year - months.first.financial_year
     diff.zero? ?  months : months.map { |month| month.advance(years: diff) }
   end
@@ -62,18 +60,18 @@ class Simulation::Insurance
   end
 
   def unemployed_term
-    months_between(from: from, to: to).map(&:beginning_of_month)
+    months_between(from: @from, to: @to).map(&:beginning_of_month)
   end
 
   def calc_medical(year, salary)
-    Simulation::Insurance::Medical.calc(year: year, local_gov_code: local_gov_code, income: salary, age: age)
+    Simulation::Insurance::Medical.calc(year: year, local_gov_code: @local_gov_code, income: salary, age: @age)
   end
 
   def calc_elderly(year, salary)
-    Simulation::Insurance::Elderly.calc(year: year, local_gov_code: local_gov_code, income: salary, age: age)
+    Simulation::Insurance::Elderly.calc(year: year, local_gov_code: @local_gov_code, income: salary, age: @age)
   end
 
   def calc_care(year, salary)
-    Simulation::Insurance::Care.calc(year: year, local_gov_code: local_gov_code, income: salary, age: age)
+    Simulation::Insurance::Care.calc(year: year, local_gov_code: @local_gov_code, income: salary, age: @age)
   end
 end

--- a/app/models/simulation/pension.rb
+++ b/app/models/simulation/pension.rb
@@ -18,10 +18,8 @@ class Simulation::Pension
 
   private
 
-  attr_reader :from, :to
-
   def calculate_pension
-    months = months_between(from: from, to: to)
+    months = months_between(from: @from, to: @to)
     fiscal_years = months.map(&:financial_year).uniq
     contribution_table = fiscal_years.index_with do |year|
       query = Pension.exists?(year: year) ? year : Pension.maximum(:year)

--- a/app/models/simulation/residence.rb
+++ b/app/models/simulation/residence.rb
@@ -32,8 +32,6 @@ class Simulation::Residence
 
   private
 
-  attr_reader :from, :to, :salary_table, :social_insurance_table
-
   def monthly_residence
     fiscal_years.flat_map do |year|
       unemployed_term = unemployed_term_by_fiscal_year[year]
@@ -64,11 +62,11 @@ class Simulation::Residence
   end
 
   def unemployed_term
-    months_between(from: from, to: to)
+    months_between(from: @from, to: @to)
   end
 
   def yearly_residence(year)
-    return 0 if salary_table[year] <= NON_TAXABLE_SALARY_LIMIT
+    return 0 if @salary_table[year] <= NON_TAXABLE_SALARY_LIMIT
 
     LocalTaxLaw.calc_determined_amount { income_basis(year) + capita_basis }
   end
@@ -98,10 +96,10 @@ class Simulation::Residence
   end
 
   def total_income(year)
-    Simulation::Salary.calc(salary_table[year])
+    Simulation::Salary.calc(@salary_table[year])
   end
 
   def income_deduction(year)
-    social_insurance_table[year] + BASIC_DEDUCTION
+    @social_insurance_table[year] + BASIC_DEDUCTION
   end
 end

--- a/app/models/simulation/salary.rb
+++ b/app/models/simulation/salary.rb
@@ -29,11 +29,9 @@ class Simulation::Salary
 
   private
 
-  attr_reader :income
-
   def calculate_salary
-    value = TABLE.select { |row| row.include?(income) }.values.first
-    base = value[:divide] == 1 ? income : (income / value[:divide]).floor(-3)
+    value = TABLE.select { |row| row.include?(@income) }.values.first
+    base = value[:divide] == 1 ? @income : (@income / value[:divide]).floor(-3)
     (base * value[:multiply]).floor + value[:plus]
   end
 end


### PR DESCRIPTION
## やったこと

- Privateなattr_readerをインスタンス変数直接参照に変更
    - 外部に公開しているAPIではなく、そもそものモチベーションが「@を減らしたい」程度のものだったので、変更しました。

Refs: #313 

---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [ ] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [ ] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [ ] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
