### PR TITLE
feat(admin::Insurance): 保険料のコピー機能を実装

### DIFF
--- a/app/controllers/admin/insurances_controller.rb
+++ b/app/controllers/admin/insurances_controller.rb
@@ -8,6 +8,9 @@ class Admin::InsurancesController < ApplicationController
 
   def new
     @insurance_form = InsuranceForm.new
+    return unless params[:id]
+
+    copy_attribute
   end
 
   def create
@@ -59,5 +62,27 @@ class Admin::InsurancesController < ApplicationController
       :care_limit,
       *InsuranceForm.calendars
     )
+  end
+
+  def copy_attribute
+    insurance = Insurance.find(params[:id])
+    payment_target_months = insurance.payment_target_months.map { _1.month.month }
+    @insurance_form.local_gov_code = insurance.local_gov_code
+    @insurance_form.medical_income_basis = insurance.medical_income_basis
+    @insurance_form.medical_asset_basis = insurance.medical_asset_basis
+    @insurance_form.medical_capita_basis = insurance.medical_capita_basis
+    @insurance_form.medical_household_basis = insurance.medical_household_basis
+    @insurance_form.medical_limit = insurance.medical_limit
+    @insurance_form.elderly_income_basis = insurance.elderly_income_basis
+    @insurance_form.elderly_asset_basis = insurance.elderly_asset_basis
+    @insurance_form.elderly_capita_basis = insurance.elderly_capita_basis
+    @insurance_form.elderly_household_basis = insurance.elderly_household_basis
+    @insurance_form.elderly_limit = insurance.elderly_limit
+    @insurance_form.care_income_basis = insurance.care_income_basis
+    @insurance_form.care_asset_basis = insurance.care_asset_basis
+    @insurance_form.care_capita_basis = insurance.care_capita_basis
+    @insurance_form.care_household_basis = insurance.care_household_basis
+    @insurance_form.care_limit = insurance.care_limit
+    PaymentTargetMonth::CALENDAR.each_value { |num| @insurance_form.send("month#{num}=", payment_target_months.any? { |month| month == num }) }
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,9 +14,10 @@ import {
   faInfoCircle,
   faRobot,
   faEdit,
-  faTrash
+  faTrash,
+  faClone
 } from '@fortawesome/free-solid-svg-icons'
 
-library.add(faInfoCircle, faRobot, faEdit, faTrash)
+library.add(faInfoCircle, faRobot, faEdit, faTrash, faClone)
 dom.watch()
 Rails.start()

--- a/app/javascript/src/components/Insurances.vue
+++ b/app/javascript/src/components/Insurances.vue
@@ -18,6 +18,7 @@
           <tr>
             <th class="admin-table-header">編集</th>
             <th class="admin-table-header">削除</th>
+            <th class="admin-table-header">コピー</th>
             <th class="admin-table-header">年度</th>
             <th class="admin-table-header">都道府県</th>
             <th class="admin-table-header">市区町村</th>
@@ -65,6 +66,13 @@
               <button @click="destroy(insurance.id)">
                 <i class="fas fa-trash"></i>
               </button>
+            </td>
+            <td class="admin-table-data-center">
+              <a
+                :href="`/admin/insurances/new?id=${insurance.id}`"
+                title="国民健康保険料複製"
+                ><i class="fas fa-clone"></i>
+              </a>
             </td>
             <td class="admin-table-data-center">{{ insurance.year }}</td>
             <td class="admin-table-data-center">

--- a/spec/system/insurance_spec.rb
+++ b/spec/system/insurance_spec.rb
@@ -21,46 +21,66 @@ RSpec.describe 'Insurance', type: :system, js: true do
   end
 
   describe 'create' do
-    let(:insurance_form) { build(:insurance_form) }
-    scenario 'create a new record' do
-      sign_in user
-      visit admin_insurances_path
-      click_link '新規登録'
+    context 'new record' do
+      let(:insurance_form) { build(:insurance_form) }
+      scenario 'create a new record' do
+        sign_in user
+        visit admin_insurances_path
+        click_link '新規登録'
 
-      expect(page).to have_content '国民健康保険料登録'
+        expect(page).to have_content '国民健康保険料登録'
 
-      within 'form[name=insurance]' do
-        fill_in '年度', with: insurance_form.year
-        # select "#{JpLocalGov.find(insurance_form.local_gov_code).prefecture} #{JpLocalGov.find(insurance_form.local_gov_code).city}", from: '市区町村名'
-        first('.choices').click
-        fill_in '所得割（医療分）', with: insurance_form.medical_income_basis
-        fill_in '資産割（医療分）', with: insurance_form.medical_asset_basis
-        fill_in '均等割（医療分）', with: insurance_form.medical_capita_basis
-        fill_in '平等割（医療分）', with: insurance_form.medical_household_basis
-        fill_in '限度額（医療分）', with: insurance_form.medical_limit
-        fill_in '所得割（後期高齢者支援分）', with: insurance_form.elderly_income_basis
-        fill_in '資産割（後期高齢者支援分）', with: insurance_form.elderly_asset_basis
-        fill_in '均等割（後期高齢者支援分）', with: insurance_form.elderly_capita_basis
-        fill_in '平等割（後期高齢者支援分）', with: insurance_form.elderly_household_basis
-        fill_in '限度額（後期高齢者支援分）', with: insurance_form.elderly_limit
-        fill_in '所得割（介護分）', with: insurance_form.care_income_basis
-        fill_in '資産割（介護分）', with: insurance_form.care_asset_basis
-        fill_in '均等割（介護分）', with: insurance_form.care_capita_basis
-        fill_in '平等割（介護分）', with: insurance_form.care_household_basis
-        fill_in '限度額（介護分）', with: insurance_form.care_limit
-        check 'insurance_month1'
-        check 'insurance_month3'
-        check 'insurance_month5'
-        check 'insurance_month7'
-        check 'insurance_month9'
-        check 'insurance_month11'
+        within 'form[name=insurance]' do
+          fill_in '年度', with: insurance_form.year
+          first('.choices').click
+          fill_in '所得割（医療分）', with: insurance_form.medical_income_basis
+          fill_in '資産割（医療分）', with: insurance_form.medical_asset_basis
+          fill_in '均等割（医療分）', with: insurance_form.medical_capita_basis
+          fill_in '平等割（医療分）', with: insurance_form.medical_household_basis
+          fill_in '限度額（医療分）', with: insurance_form.medical_limit
+          fill_in '所得割（後期高齢者支援分）', with: insurance_form.elderly_income_basis
+          fill_in '資産割（後期高齢者支援分）', with: insurance_form.elderly_asset_basis
+          fill_in '均等割（後期高齢者支援分）', with: insurance_form.elderly_capita_basis
+          fill_in '平等割（後期高齢者支援分）', with: insurance_form.elderly_household_basis
+          fill_in '限度額（後期高齢者支援分）', with: insurance_form.elderly_limit
+          fill_in '所得割（介護分）', with: insurance_form.care_income_basis
+          fill_in '資産割（介護分）', with: insurance_form.care_asset_basis
+          fill_in '均等割（介護分）', with: insurance_form.care_capita_basis
+          fill_in '平等割（介護分）', with: insurance_form.care_household_basis
+          fill_in '限度額（介護分）', with: insurance_form.care_limit
+          check 'insurance_month1'
+          check 'insurance_month3'
+          check 'insurance_month5'
+          check 'insurance_month7'
+          check 'insurance_month9'
+          check 'insurance_month11'
+        end
+
+        expect { click_button '登録' }
+          .to change { Insurance.count }.from(0).to(1)
+                                        .and change { PaymentTargetMonth.count }.from(0).to(6)
+        assert_current_path admin_insurances_path
+        assert_text '保険料率を保存しました。'
       end
+    end
 
-      expect { click_button '登録' }
-        .to change { Insurance.count }.from(0).to(1)
-                                      .and change { PaymentTargetMonth.count }.from(0).to(6)
-      assert_current_path admin_insurances_path
-      assert_text '保険料率を保存しました。'
+    context 'copy record' do
+      before { @insurance = create(:insurance, :with_payment_target_months, months: [1, 2, 3, 6, 7, 8, 9, 10, 11, 12], year: 2021, local_gov_code: '162019') }
+      scenario 'copy and create a record' do
+        sign_in user
+        visit admin_insurances_path
+        click_link '国民健康保険料複製'
+
+        expect(page).to have_content '国民健康保険料登録'
+
+        fill_in '年度', with: 2022
+
+        expect { click_button '登録' }
+          .to change { Insurance.count }.from(1).to(2)
+                                        .and change { PaymentTargetMonth.count }.from(10).to(20)
+        assert_current_path admin_insurances_path
+        assert_text '保険料率を保存しました。'
+      end
     end
   end
 
@@ -106,27 +126,26 @@ RSpec.describe 'Insurance', type: :system, js: true do
       assert_text '保険料率を更新しました。'
 
       tds = page.all('td')
-      expect(tds[2]).to have_content '2021'
-      expect(tds[4]).to have_content '富山市'
-      expect(tds[6]).to have_content '7.20'
-      expect(tds[7]).to have_content '0.50'
-      expect(tds[8]).to have_content '¥10,000'
-      expect(tds[9]).to have_content '¥30,000'
-      expect(tds[10]).to have_content '¥20,000'
-      expect(tds[11]).to have_content '2.94'
-      expect(tds[12]).to have_content '0.00'
-      expect(tds[13]).to have_content '¥6,000'
-      expect(tds[14]).to have_content '¥10,000'
-      expect(tds[15]).to have_content '¥21,000'
-      expect(tds[16]).to have_content '2.76'
-      expect(tds[17]).to have_content '0.00'
-      expect(tds[18]).to have_content '¥6,728'
-      expect(tds[19]).to have_content '¥7,890'
-      expect(tds[20]).to have_content '¥12,000'
-      expect(tds[21]).to have_content '-'
-      expect(tds[22]).to have_content '○'
-      expect(tds[23]).to have_content '-'
-      expect(tds[24]).to have_content '○'
+      expect(tds[3]).to have_content '2021'
+      expect(tds[5]).to have_content '富山市'
+      expect(tds[7]).to have_content '7.20'
+      expect(tds[8]).to have_content '0.50'
+      expect(tds[9]).to have_content '¥10,000'
+      expect(tds[10]).to have_content '¥30,000'
+      expect(tds[11]).to have_content '¥20,000'
+      expect(tds[12]).to have_content '2.94'
+      expect(tds[13]).to have_content '0.00'
+      expect(tds[14]).to have_content '¥6,000'
+      expect(tds[15]).to have_content '¥10,000'
+      expect(tds[16]).to have_content '¥21,000'
+      expect(tds[17]).to have_content '2.76'
+      expect(tds[18]).to have_content '0.00'
+      expect(tds[19]).to have_content '¥6,728'
+      expect(tds[20]).to have_content '¥7,890'
+      expect(tds[21]).to have_content '¥12,000'
+      expect(tds[22]).to have_content '-'
+      expect(tds[23]).to have_content '○'
+      expect(tds[24]).to have_content '-'
       expect(tds[25]).to have_content '○'
       expect(tds[26]).to have_content '○'
       expect(tds[27]).to have_content '○'
@@ -135,6 +154,7 @@ RSpec.describe 'Insurance', type: :system, js: true do
       expect(tds[30]).to have_content '○'
       expect(tds[31]).to have_content '○'
       expect(tds[32]).to have_content '○'
+      expect(tds[33]).to have_content '○'
     end
   end
 


### PR DESCRIPTION
Closes: #291

## やったこと

- 保険料一覧画面にコピー機能を作成
    - 対象のレコードの「年度」以外の値をコピーする（基本的なユースケースは前年度のレコードを参考にするケースであるため）

## UIの変更

![CleanShot 2022-04-16 at 04 45 17](https://user-images.githubusercontent.com/61409641/163625247-97258fab-888c-487d-9270-123377f01f59.png)


## 動作イメージ

![CleanShot 2022-04-16 at 04 44 32](https://user-images.githubusercontent.com/61409641/163625193-47f39706-f204-4ed7-ad30-9d9c0097cf19.gif)




---

PR提出前のチェックリスト:

- [x] PRの関心は**ただ一つ**だけになっている & 文法的に正しく、明確かつ完全なタイトルと本文になっている
- [x] [良いコミットメッセージ][1]を書いている
- [x] 関連issueがある場合、コミットメッセージに[Closing Keywords][2]を使っている
- [x] Featureブランチは最新版の`main`ブランチに追随している (そうでなければrebaseすること)
- [x] 関連するコミットはsquashした
- [x] テストを追加した
- [x] `bin/lint`と`bin/rspec`を実行した

[1]: https://postd.cc/how-to-write-a-git-commit-message/

[2]: https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
